### PR TITLE
frontend entities should be visible for admins only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
 before_script:
   - psql -c "CREATE DATABASE event_planner_integration;" -U postgres
   - psql -c "CREATE USER event_planner WITH PASSWORD 'event_planner_password';" -U postgres
+  - psql -c "GRANT ALL PRIVILEGES ON DATABASE event_planner_integration TO event_planner;" -U postgres
 
 script:
   - if [[ "${MAIN_BUILD}" != "" && "${MAIN_BUILD}" == "true" ]]; then export GRADLE_COMMAND="build jacocoTestReport sonarqube"; else export GRADLE_COMMAND="check"; fi

--- a/src/main/webapp/app/entities/invitation/invitation.route.ts
+++ b/src/main/webapp/app/entities/invitation/invitation.route.ts
@@ -39,7 +39,7 @@ export const invitationRoute: Routes = [
     path: '',
     component: InvitationComponent,
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       defaultSort: 'id,asc',
       pageTitle: 'eventPlannerApp.invitation.home.title',
     },
@@ -52,7 +52,7 @@ export const invitationRoute: Routes = [
       invitation: InvitationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.invitation.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -64,7 +64,7 @@ export const invitationRoute: Routes = [
       invitation: InvitationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.invitation.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -76,7 +76,7 @@ export const invitationRoute: Routes = [
       invitation: InvitationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.invitation.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/entities/location/location.route.ts
+++ b/src/main/webapp/app/entities/location/location.route.ts
@@ -39,7 +39,7 @@ export const locationRoute: Routes = [
     path: '',
     component: LocationComponent,
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       defaultSort: 'id,asc',
       pageTitle: 'eventPlannerApp.location.home.title',
     },
@@ -52,7 +52,7 @@ export const locationRoute: Routes = [
       location: LocationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.location.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -64,7 +64,7 @@ export const locationRoute: Routes = [
       location: LocationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.location.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -76,7 +76,7 @@ export const locationRoute: Routes = [
       location: LocationResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.location.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/entities/project/project.route.ts
+++ b/src/main/webapp/app/entities/project/project.route.ts
@@ -39,7 +39,7 @@ export const projectRoute: Routes = [
     path: '',
     component: ProjectComponent,
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       defaultSort: 'id,asc',
       pageTitle: 'eventPlannerApp.project.home.title',
     },
@@ -52,7 +52,7 @@ export const projectRoute: Routes = [
       project: ProjectResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.project.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -64,7 +64,7 @@ export const projectRoute: Routes = [
       project: ProjectResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.project.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -76,7 +76,7 @@ export const projectRoute: Routes = [
       project: ProjectResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.project.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/entities/responsibility/responsibility.route.ts
+++ b/src/main/webapp/app/entities/responsibility/responsibility.route.ts
@@ -39,7 +39,7 @@ export const responsibilityRoute: Routes = [
     path: '',
     component: ResponsibilityComponent,
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       defaultSort: 'id,asc',
       pageTitle: 'eventPlannerApp.responsibility.home.title',
     },
@@ -52,7 +52,7 @@ export const responsibilityRoute: Routes = [
       responsibility: ResponsibilityResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.responsibility.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -64,7 +64,7 @@ export const responsibilityRoute: Routes = [
       responsibility: ResponsibilityResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.responsibility.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -76,7 +76,7 @@ export const responsibilityRoute: Routes = [
       responsibility: ResponsibilityResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.responsibility.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/entities/role/role.component.ts
+++ b/src/main/webapp/app/entities/role/role.component.ts
@@ -82,9 +82,6 @@ export class RoleComponent implements OnInit, OnDestroy {
 
   sort(): string[] {
     const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
-    if (this.predicate !== 'id') {
-      result.push('id');
-    }
     return result;
   }
 

--- a/src/main/webapp/app/entities/role/role.route.ts
+++ b/src/main/webapp/app/entities/role/role.route.ts
@@ -16,9 +16,9 @@ export class RoleResolve implements Resolve<IRole> {
   constructor(private service: RoleService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<IRole> | Observable<never> {
-    const id = route.params['id'];
-    if (id) {
-      return this.service.find(id).pipe(
+    const name = route.params['name'];
+    if (name) {
+      return this.service.find(name).pipe(
         flatMap((role: HttpResponse<Role>) => {
           if (role.body) {
             return of(role.body);
@@ -38,20 +38,20 @@ export const roleRoute: Routes = [
     path: '',
     component: RoleComponent,
     data: {
-      authorities: [Authority.USER],
-      defaultSort: 'id,asc',
+      authorities: [Authority.ADMIN],
+      defaultSort: 'name,asc',
       pageTitle: 'eventPlannerApp.role.home.title',
     },
     canActivate: [UserRouteAccessService],
   },
   {
-    path: ':id/view',
+    path: ':name/view',
     component: RoleDetailComponent,
     resolve: {
       role: RoleResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.role.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/entities/section/section.route.ts
+++ b/src/main/webapp/app/entities/section/section.route.ts
@@ -39,7 +39,7 @@ export const sectionRoute: Routes = [
     path: '',
     component: SectionComponent,
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       defaultSort: 'id,asc',
       pageTitle: 'eventPlannerApp.section.home.title',
     },
@@ -52,7 +52,7 @@ export const sectionRoute: Routes = [
       section: SectionResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.section.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -64,7 +64,7 @@ export const sectionRoute: Routes = [
       section: SectionResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.section.home.title',
     },
     canActivate: [UserRouteAccessService],
@@ -76,7 +76,7 @@ export const sectionRoute: Routes = [
       section: SectionResolve,
     },
     data: {
-      authorities: [Authority.USER],
+      authorities: [Authority.ADMIN],
       pageTitle: 'eventPlannerApp.section.home.title',
     },
     canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -17,7 +17,7 @@
                 </a>
             </li>
             <!-- jhipster-needle-add-element-to-menu - JHipster will add new menu items here -->
-            <li *ngSwitchCase="true" ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+            <li *jhiHasAnyAuthority="'ROLE_ADMIN'" ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="entity-menu">
                     <span>
                         <fa-icon icon="th-list"></fa-icon>

--- a/src/test/javascript/spec/app/entities/role/role.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/role/role.component.spec.ts
@@ -23,13 +23,13 @@ describe('Component Tests', () => {
             provide: ActivatedRoute,
             useValue: {
               data: of({
-                defaultSort: 'id,asc',
+                defaultSort: 'name,asc',
               }),
               queryParamMap: of(
                 convertToParamMap({
                   page: '1',
                   size: '1',
-                  sort: 'id,desc',
+                  sort: 'name,desc',
                 })
               ),
             },
@@ -90,21 +90,7 @@ describe('Component Tests', () => {
       const result = comp.sort();
 
       // THEN
-      expect(result).toEqual(['id,desc']);
-    });
-
-    it('should calculate the sort attribute for a non-id attribute', () => {
-      // INIT
-      comp.ngOnInit();
-
-      // GIVEN
-      comp.predicate = 'name';
-
-      // WHEN
-      const result = comp.sort();
-
-      // THEN
-      expect(result).toEqual(['name,desc', 'id']);
+      expect(result).toEqual(['name,desc']);
     });
   });
 });


### PR DESCRIPTION
PR contains:
* frontend entity protection, routes accessible for `ADMIN` instead of `USER`
* bugfix when showing `Role`s (name is primary key, not id)
* travis-ci PostgreSQL security fix

those entitiy sites accessible for `ADMIN` are not the "business" pages. the functional pages will be created in stories 1 to 6.