### PR TITLE
#34 remove nondeterministic find all assertions.

### DIFF
--- a/src/test/java/io/github/bbortt/event/planner/web/rest/InvitationResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/InvitationResourceIT.java
@@ -123,7 +123,8 @@ public class InvitationResourceIT {
     @Test
     @Transactional
     public void createInvitation() throws Exception {
-        int databaseSizeBeforeCreate = invitationRepository.findAll().size();
+        invitationRepository.deleteAll();
+
         // Create the Invitation
         restInvitationMockMvc
             .perform(
@@ -133,8 +134,8 @@ public class InvitationResourceIT {
 
         // Validate the Invitation in the database
         List<Invitation> invitationList = invitationRepository.findAll();
-        assertThat(invitationList).hasSize(databaseSizeBeforeCreate + 1);
-        Invitation testInvitation = invitationList.get(invitationList.size() - 1);
+        assertThat(invitationList).hasSize(1);
+        Invitation testInvitation = invitationList.get(0);
         assertThat(testInvitation.getEmail()).isEqualTo(DEFAULT_EMAIL);
         assertThat(testInvitation.isAccepted()).isEqualTo(DEFAULT_ACCEPTED);
     }
@@ -261,7 +262,11 @@ public class InvitationResourceIT {
         // Validate the Invitation in the database
         List<Invitation> invitationList = invitationRepository.findAll();
         assertThat(invitationList).hasSize(databaseSizeBeforeUpdate);
-        Invitation testInvitation = invitationList.get(invitationList.size() - 1);
+        Invitation testInvitation = invitationList
+            .stream()
+            .filter(invitation -> updatedInvitation.getId().equals(invitation.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find updated invitation!"));
         assertThat(testInvitation.getEmail()).isEqualTo(UPDATED_EMAIL);
         assertThat(testInvitation.isAccepted()).isEqualTo(UPDATED_ACCEPTED);
     }

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/LocationResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/LocationResourceIT.java
@@ -3,8 +3,13 @@ package io.github.bbortt.event.planner.web.rest;
 import static io.github.bbortt.event.planner.web.rest.TestUtil.sameInstant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.bbortt.event.planner.EventPlannerApp;
 import io.github.bbortt.event.planner.domain.Location;
@@ -60,8 +65,7 @@ public class LocationResourceIT {
     /**
      * Create an entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Location createEntity(EntityManager em) {
         Location location = new Location().name(DEFAULT_NAME).dateFrom(DEFAULT_DATE_FROM).dateTo(DEFAULT_DATE_TO);
@@ -81,8 +85,7 @@ public class LocationResourceIT {
     /**
      * Create an updated entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Location createUpdatedEntity(EntityManager em) {
         Location location = new Location().name(UPDATED_NAME).dateFrom(UPDATED_DATE_FROM).dateTo(UPDATED_DATE_TO);
@@ -107,7 +110,8 @@ public class LocationResourceIT {
     @Test
     @Transactional
     public void createLocation() throws Exception {
-        int databaseSizeBeforeCreate = locationRepository.findAll().size();
+        locationRepository.deleteAll();
+
         // Create the Location
         restLocationMockMvc
             .perform(post("/api/locations").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(location)))
@@ -115,8 +119,8 @@ public class LocationResourceIT {
 
         // Validate the Location in the database
         List<Location> locationList = locationRepository.findAll();
-        assertThat(locationList).hasSize(databaseSizeBeforeCreate + 1);
-        Location testLocation = locationList.get(locationList.size() - 1);
+        assertThat(locationList).hasSize(1);
+        Location testLocation = locationList.get(0);
         assertThat(testLocation.getName()).isEqualTo(DEFAULT_NAME);
         assertThat(testLocation.getDateFrom()).isEqualTo(DEFAULT_DATE_FROM);
         assertThat(testLocation.getDateTo()).isEqualTo(DEFAULT_DATE_TO);
@@ -255,7 +259,11 @@ public class LocationResourceIT {
         // Validate the Location in the database
         List<Location> locationList = locationRepository.findAll();
         assertThat(locationList).hasSize(databaseSizeBeforeUpdate);
-        Location testLocation = locationList.get(locationList.size() - 1);
+        Location testLocation = locationList
+            .stream()
+            .filter(location -> updatedLocation.getId().equals(location.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find updated location!"));
         assertThat(testLocation.getName()).isEqualTo(UPDATED_NAME);
         assertThat(testLocation.getDateFrom()).isEqualTo(UPDATED_DATE_FROM);
         assertThat(testLocation.getDateTo()).isEqualTo(UPDATED_DATE_TO);

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/ProjectResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/ProjectResourceIT.java
@@ -3,8 +3,13 @@ package io.github.bbortt.event.planner.web.rest;
 import static io.github.bbortt.event.planner.web.rest.TestUtil.sameInstant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.bbortt.event.planner.EventPlannerApp;
 import io.github.bbortt.event.planner.domain.Project;
@@ -62,8 +67,7 @@ public class ProjectResourceIT {
     /**
      * Create an entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Project createEntity(EntityManager em) {
         Project project = new Project()
@@ -77,8 +81,7 @@ public class ProjectResourceIT {
     /**
      * Create an updated entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Project createUpdatedEntity(EntityManager em) {
         Project project = new Project()
@@ -97,7 +100,8 @@ public class ProjectResourceIT {
     @Test
     @Transactional
     public void createProject() throws Exception {
-        int databaseSizeBeforeCreate = projectRepository.findAll().size();
+        projectRepository.deleteAll();
+
         // Create the Project
         restProjectMockMvc
             .perform(post("/api/projects").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(project)))
@@ -105,8 +109,8 @@ public class ProjectResourceIT {
 
         // Validate the Project in the database
         List<Project> projectList = projectRepository.findAll();
-        assertThat(projectList).hasSize(databaseSizeBeforeCreate + 1);
-        Project testProject = projectList.get(projectList.size() - 1);
+        assertThat(projectList).hasSize(1);
+        Project testProject = projectList.get(0);
         assertThat(testProject.getName()).isEqualTo(DEFAULT_NAME);
         assertThat(testProject.getDescription()).isEqualTo(DEFAULT_DESCRIPTION);
         assertThat(testProject.getStartTime()).isEqualTo(DEFAULT_START_TIME);
@@ -248,7 +252,11 @@ public class ProjectResourceIT {
         // Validate the Project in the database
         List<Project> projectList = projectRepository.findAll();
         assertThat(projectList).hasSize(databaseSizeBeforeUpdate);
-        Project testProject = projectList.get(projectList.size() - 1);
+        Project testProject = projectList
+            .stream()
+            .filter(project -> updatedProject.getId().equals(project.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find updated project!"));
         assertThat(testProject.getName()).isEqualTo(UPDATED_NAME);
         assertThat(testProject.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
         assertThat(testProject.getStartTime()).isEqualTo(UPDATED_START_TIME);

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResourceIT.java
@@ -2,8 +2,13 @@ package io.github.bbortt.event.planner.web.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.bbortt.event.planner.EventPlannerApp;
 import io.github.bbortt.event.planner.domain.Project;
@@ -49,8 +54,7 @@ public class ResponsibilityResourceIT {
     /**
      * Create an entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Responsibility createEntity(EntityManager em) {
         Responsibility responsibility = new Responsibility().name(DEFAULT_NAME);
@@ -70,8 +74,7 @@ public class ResponsibilityResourceIT {
     /**
      * Create an updated entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Responsibility createUpdatedEntity(EntityManager em) {
         Responsibility responsibility = new Responsibility().name(UPDATED_NAME);
@@ -96,7 +99,8 @@ public class ResponsibilityResourceIT {
     @Test
     @Transactional
     public void createResponsibility() throws Exception {
-        int databaseSizeBeforeCreate = responsibilityRepository.findAll().size();
+        responsibilityRepository.deleteAll();
+
         // Create the Responsibility
         restResponsibilityMockMvc
             .perform(
@@ -108,8 +112,8 @@ public class ResponsibilityResourceIT {
 
         // Validate the Responsibility in the database
         List<Responsibility> responsibilityList = responsibilityRepository.findAll();
-        assertThat(responsibilityList).hasSize(databaseSizeBeforeCreate + 1);
-        Responsibility testResponsibility = responsibilityList.get(responsibilityList.size() - 1);
+        assertThat(responsibilityList).hasSize(1);
+        Responsibility testResponsibility = responsibilityList.get(0);
         assertThat(testResponsibility.getName()).isEqualTo(DEFAULT_NAME);
     }
 
@@ -218,7 +222,11 @@ public class ResponsibilityResourceIT {
         // Validate the Responsibility in the database
         List<Responsibility> responsibilityList = responsibilityRepository.findAll();
         assertThat(responsibilityList).hasSize(databaseSizeBeforeUpdate);
-        Responsibility testResponsibility = responsibilityList.get(responsibilityList.size() - 1);
+        Responsibility testResponsibility = responsibilityList
+            .stream()
+            .filter(responsibility -> updatedResponsibility.getId().equals(responsibility.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find updated responsibility!"));
         assertThat(testResponsibility.getName()).isEqualTo(UPDATED_NAME);
     }
 

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/SectionResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/SectionResourceIT.java
@@ -2,8 +2,13 @@ package io.github.bbortt.event.planner.web.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.bbortt.event.planner.EventPlannerApp;
 import io.github.bbortt.event.planner.domain.Location;
@@ -49,8 +54,7 @@ public class SectionResourceIT {
     /**
      * Create an entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Section createEntity(EntityManager em) {
         Section section = new Section().name(DEFAULT_NAME);
@@ -70,8 +74,7 @@ public class SectionResourceIT {
     /**
      * Create an updated entity for this test.
      *
-     * This is a static method, as tests for other entities might also need it,
-     * if they test an entity which requires the current entity.
+     * This is a static method, as tests for other entities might also need it, if they test an entity which requires the current entity.
      */
     public static Section createUpdatedEntity(EntityManager em) {
         Section section = new Section().name(UPDATED_NAME);
@@ -96,7 +99,8 @@ public class SectionResourceIT {
     @Test
     @Transactional
     public void createSection() throws Exception {
-        int databaseSizeBeforeCreate = sectionRepository.findAll().size();
+        sectionRepository.deleteAll();
+
         // Create the Section
         restSectionMockMvc
             .perform(post("/api/sections").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(section)))
@@ -104,8 +108,8 @@ public class SectionResourceIT {
 
         // Validate the Section in the database
         List<Section> sectionList = sectionRepository.findAll();
-        assertThat(sectionList).hasSize(databaseSizeBeforeCreate + 1);
-        Section testSection = sectionList.get(sectionList.size() - 1);
+        assertThat(sectionList).hasSize(1);
+        Section testSection = sectionList.get(0);
         assertThat(testSection.getName()).isEqualTo(DEFAULT_NAME);
     }
 
@@ -204,7 +208,11 @@ public class SectionResourceIT {
         // Validate the Section in the database
         List<Section> sectionList = sectionRepository.findAll();
         assertThat(sectionList).hasSize(databaseSizeBeforeUpdate);
-        Section testSection = sectionList.get(sectionList.size() - 1);
+        Section testSection = sectionList
+            .stream()
+            .filter(section -> updatedSection.getId().equals(section.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find updated section!"));
         assertThat(testSection.getName()).isEqualTo(UPDATED_NAME);
     }
 

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/UserResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/UserResourceIT.java
@@ -119,7 +119,7 @@ public class UserResourceIT {
     @Test
     @Transactional
     public void createUser() throws Exception {
-        int databaseSizeBeforeCreate = userRepository.findAll().size();
+        userRepository.deleteAll();
 
         // Create the User
         ManagedUserVM managedUserVM = new ManagedUserVM();
@@ -140,8 +140,8 @@ public class UserResourceIT {
         // Validate the User in the database
         assertPersistedUsers(
             users -> {
-                assertThat(users).hasSize(databaseSizeBeforeCreate + 1);
-                User testUser = users.get(users.size() - 1);
+                assertThat(users).hasSize(1);
+                User testUser = users.get(0);
                 assertThat(testUser.getLogin()).isEqualTo(DEFAULT_LOGIN);
                 assertThat(testUser.getFirstName()).isEqualTo(DEFAULT_FIRSTNAME);
                 assertThat(testUser.getLastName()).isEqualTo(DEFAULT_LASTNAME);
@@ -314,7 +314,11 @@ public class UserResourceIT {
         assertPersistedUsers(
             users -> {
                 assertThat(users).hasSize(databaseSizeBeforeUpdate);
-                User testUser = users.get(users.size() - 1);
+                User testUser = users
+                    .stream()
+                    .filter(user -> updatedUser.getId().equals(user.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Cannot find updated user!"));
                 assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
                 assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
                 assertThat(testUser.getEmail()).isEqualTo(UPDATED_EMAIL);
@@ -358,7 +362,11 @@ public class UserResourceIT {
         assertPersistedUsers(
             users -> {
                 assertThat(users).hasSize(databaseSizeBeforeUpdate);
-                User testUser = users.get(users.size() - 1);
+                User testUser = users
+                    .stream()
+                    .filter(user -> updatedUser.getId().equals(user.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Cannot find updated user!"));
                 assertThat(testUser.getLogin()).isEqualTo(UPDATED_LOGIN);
                 assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
                 assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);


### PR DESCRIPTION
fixes non-deterministic `findAll` repository behavior. this heavily relies on database implementation, order by primary key (nor any other) is not guaranteed!

closes #34 .