### PR TITLE
EP-2 prepare global router outlet routes.

### DIFF
--- a/src/main/webapp/app/view/modal-outlets.routes.ts
+++ b/src/main/webapp/app/view/modal-outlets.routes.ts
@@ -1,0 +1,11 @@
+import { Routes } from '@angular/router';
+
+import { CreateProjectModalComponent } from 'app/view/create-project/create-project-modal.component';
+
+export const MODAL_OUTLET_ROUTES: Routes = [
+  {
+    path: 'create-project',
+    component: CreateProjectModalComponent,
+    outlet: 'modal',
+  },
+];

--- a/src/main/webapp/app/view/view.routes.ts
+++ b/src/main/webapp/app/view/view.routes.ts
@@ -1,7 +1,8 @@
 import { Routes } from '@angular/router';
 
 import { HomeComponent } from './home.component';
-import { CreateProjectModalComponent } from 'app/view/create-project/create-project-modal.component';
+
+import { MODAL_OUTLET_ROUTES } from 'app/view/modal-outlets.routes';
 
 export const VIEW_ROUTES: Routes = [
   {
@@ -16,9 +17,5 @@ export const VIEW_ROUTES: Routes = [
     path: 'project',
     loadChildren: () => import('./project/project.module').then(m => m.EventPlannerProjectModule),
   },
-  {
-    path: 'create-project',
-    component: CreateProjectModalComponent,
-    outlet: 'modal',
-  },
+  ...MODAL_OUTLET_ROUTES,
 ];


### PR DESCRIPTION
PR contains: 
* separated global router outlet routes

angular does not allow routes on outlets combined with the lazy loaded modules. it's a known bug. therefore all outlet routes will have to be registered at the root level. a separate outlet-route file makes sense.