### PR TITLE
EP-16 fix project routing bugs.

### DIFF
--- a/src/main/webapp/app/entities/project/project.route.ts
+++ b/src/main/webapp/app/entities/project/project.route.ts
@@ -17,7 +17,15 @@ export class ProjectResolve implements Resolve<IProject> {
   constructor(private service: ProjectService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<IProject> | Observable<never> {
-    const projectId = route.params['projectId'];
+    let projectId = route.params['projectId'];
+
+    // Search recursively for Route.children
+    let parent = route.parent;
+    while (!projectId && parent) {
+      projectId = parent.params['projectId'];
+      parent = parent.parent;
+    }
+
     if (projectId) {
       return this.service.find(projectId).pipe(
         flatMap((project: HttpResponse<Project>) => {

--- a/src/main/webapp/app/view/modal-outlets.routes.ts
+++ b/src/main/webapp/app/view/modal-outlets.routes.ts
@@ -4,7 +4,7 @@ import { CreateProjectModalComponent } from 'app/view/create-project/create-proj
 
 export const MODAL_OUTLET_ROUTES: Routes = [
   {
-    path: 'create-project',
+    path: 'projects/create',
     component: CreateProjectModalComponent,
     outlet: 'modal',
   },

--- a/src/main/webapp/app/view/my-projects/my-projects.component.html
+++ b/src/main/webapp/app/view/my-projects/my-projects.component.html
@@ -17,7 +17,7 @@
                 </span>
             </button>
 
-            <button id="jh-create-entity" [routerLink]="[{outlets: {modal: 'create-project'}}]"
+            <button id="jh-create-entity" [routerLink]="[{outlets: {modal: ['projects', 'create']}}]"
                     class="btn btn-primary jh-create-entity create-project">
                 <fa-icon icon="plus"></fa-icon>
                 <span jhiTranslate="eventPlannerApp.project.home.createLabel">

--- a/src/main/webapp/app/view/project/admin/navbar/project-navbar.component.html
+++ b/src/main/webapp/app/view/project/admin/navbar/project-navbar.component.html
@@ -2,7 +2,7 @@
     <nav class="navbar navbar-light bg-light">
         <ul class="navbar-nav w-100 flex-row align-items-stretch">
             <li *ngFor="let link of navLinks" class="nav-item w-100" routerLinkActive="active"
-                [routerLinkActiveOptions]="{ exact: true }">
+                [routerLinkActiveOptions]="{ exact: false }">
                 <a class="nav-link" routerLink="{{link.routerLink}}">
                     <span>
                         <fa-icon [icon]="link.icon"></fa-icon>

--- a/src/main/webapp/app/view/project/admin/project-admin.component.ts
+++ b/src/main/webapp/app/view/project/admin/project-admin.component.ts
@@ -14,7 +14,11 @@ export class ProjectAdminComponent implements OnInit {
   constructor(private router: Router, private activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
-    this.activatedRoute.data.subscribe(({ project }) => (this.project = project));
-    this.router.navigate(['locations'], { relativeTo: this.activatedRoute.parent });
+    this.activatedRoute.data.subscribe(({ project }) => {
+      this.project = project;
+      if (this.router.isActive(`/project/${(project as Project).id!}/admin`, true)) {
+        this.router.navigate(['locations'], { relativeTo: this.activatedRoute.parent });
+      }
+    });
   }
 }

--- a/src/main/webapp/app/view/project/admin/project-admin.routes.ts
+++ b/src/main/webapp/app/view/project/admin/project-admin.routes.ts
@@ -25,23 +25,14 @@ export const PROJECT_ADMIN_ROUTES: Routes = [
       {
         path: 'locations',
         component: ProjectLocationsComponent,
-        data: {
-          defaultSort: 'id,asc',
-        },
       },
       {
         path: 'users',
         component: ProjectUsersComponent,
-        data: {
-          defaultSort: 'id,asc',
-        },
       },
       {
         path: 'responsibilities',
         component: ProjectResponsibilitiesComponent,
-        data: {
-          defaultSort: 'id,asc',
-        },
       },
     ],
   },

--- a/src/main/webapp/app/view/view.routes.ts
+++ b/src/main/webapp/app/view/view.routes.ts
@@ -16,7 +16,7 @@ export const VIEW_ROUTES: Routes = [
     loadChildren: () => import('./project/project.module').then(m => m.EventPlannerProjectModule),
   },
   {
-    path: 'create-project',
+    path: 'projects/create',
     component: CreateProjectModalComponent,
     outlet: 'modal',
   },


### PR DESCRIPTION
PR contains:
* `ProjectResolver` didn't search for `projectId` recursively
* modal routes didn't match global routing style
* project administrative navbar did use exact route matching
  * tabs aren't active when modals open
* remove project admin routes sort param