### PR TITLE
attempt to solve n+1 query problem when paginating locations

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
@@ -1,8 +1,8 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Location;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +11,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    Page<Location> findAllByProjectId(Long projectId, Pageable pageable);
+    @EntityGraph(attributePaths = { "sections" })
+    List<Location> findAllByProjectId(Long projectId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
@@ -1,11 +1,8 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Location;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,7 +11,5 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    @EntityGraph(attributePaths = { "sections" })
-    @Fetch(FetchMode.JOIN)
     Page<Location> findAllByProjectId(Long projectId, Pageable pageable);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
@@ -1,12 +1,11 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Section;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 /**
  * Spring Data  repository for the Section entity.
  */
-@SuppressWarnings("unused")
 @Repository
 public interface SectionRepository extends JpaRepository<Section, Long> {}

--- a/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
@@ -3,6 +3,7 @@ package io.github.bbortt.event.planner.service;
 import io.github.bbortt.event.planner.domain.Location;
 import io.github.bbortt.event.planner.repository.LocationRepository;
 import io.github.bbortt.event.planner.repository.SectionRepository;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,11 +22,9 @@ public class LocationService {
     private final Logger log = LoggerFactory.getLogger(LocationService.class);
 
     private final LocationRepository locationRepository;
-    private final SectionRepository sectionRepository;
 
-    public LocationService(LocationRepository locationRepository, SectionRepository sectionRepository) {
+    public LocationService(LocationRepository locationRepository) {
         this.locationRepository = locationRepository;
-        this.sectionRepository = sectionRepository;
     }
 
     /**
@@ -77,23 +76,10 @@ public class LocationService {
      * Find all Locations for the given project.
      *
      * @param projectId the project to retrieve locations for.
-     * @param pageable  the pagination information.
      * @return the list of entities.
      */
-    public Page<Location> findAllByProjectId(Long projectId, Pageable pageable) {
+    public List<Location> findAllByProjectId(Long projectId) {
         log.debug("Request to get all Locations for Project {}", projectId);
-        return locationRepository.findAllByProjectId(projectId, pageable).map(this::fetchSections);
-    }
-
-    /**
-     * Resolve section entity graph based on given location.
-     *
-     * @param location the location.
-     * @return the enriched location.
-     */
-    private Location fetchSections(Location location) {
-        log.debug("Enrich location {} with sections", location.getId());
-        location.sections(sectionRepository.findAllByLocationId(location.getId()));
-        return location;
+        return locationRepository.findAllByProjectId(projectId);
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
@@ -2,6 +2,7 @@ package io.github.bbortt.event.planner.service;
 
 import io.github.bbortt.event.planner.domain.Location;
 import io.github.bbortt.event.planner.repository.LocationRepository;
+import io.github.bbortt.event.planner.repository.SectionRepository;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +21,11 @@ public class LocationService {
     private final Logger log = LoggerFactory.getLogger(LocationService.class);
 
     private final LocationRepository locationRepository;
+    private final SectionRepository sectionRepository;
 
-    public LocationService(LocationRepository locationRepository) {
+    public LocationService(LocationRepository locationRepository, SectionRepository sectionRepository) {
         this.locationRepository = locationRepository;
+        this.sectionRepository = sectionRepository;
     }
 
     /**
@@ -70,7 +73,27 @@ public class LocationService {
         locationRepository.deleteById(id);
     }
 
+    /**
+     * Find all Locations for the given project.
+     *
+     * @param projectId the project to retrieve locations for.
+     * @param pageable  the pagination information.
+     * @return the list of entities.
+     */
     public Page<Location> findAllByProjectId(Long projectId, Pageable pageable) {
-        return locationRepository.findAllByProjectId(projectId, pageable);
+        log.debug("Request to get all Locations for Project {}", projectId);
+        return locationRepository.findAllByProjectId(projectId, pageable).map(this::fetchSections);
+    }
+
+    /**
+     * Resolve section entity graph based on given location.
+     *
+     * @param location the location.
+     * @return the enriched location.
+     */
+    private Location fetchSections(Location location) {
+        log.debug("Enrich location {} with sections", location.getId());
+        location.sections(sectionRepository.findAllByLocationId(location.getId()));
+        return location;
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
@@ -52,7 +52,8 @@ public class LocationResource {
      * {@code POST  /locations} : Create a new location.
      *
      * @param location the location to create.
-     * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new location, or with status {@code 400 (Bad Request)} if the location has already an ID.
+     * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new
+     * location, or with status {@code 400 (Bad Request)} if the location has already an ID.
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PostMapping("/locations")
@@ -72,7 +73,9 @@ public class LocationResource {
      * {@code PUT  /locations} : Updates an existing location.
      *
      * @param location the location to update.
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated location, or with status {@code 400 (Bad Request)} if the location is not valid, or with status {@code 500 (Internal Server Error)} if the location couldn't be updated.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated
+     * location, or with status {@code 400 (Bad Request)} if the location is not valid, or with
+     * status {@code 500 (Internal Server Error)} if the location couldn't be updated.
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/locations")
@@ -92,7 +95,8 @@ public class LocationResource {
      * {@code GET  /locations} : get all the locations.
      *
      * @param pageable the pagination information.
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of locations in body.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of locations in
+     * body.
      */
     @GetMapping("/locations")
     public ResponseEntity<List<Location>> getAllLocations(Pageable pageable) {
@@ -106,7 +110,8 @@ public class LocationResource {
      * {@code GET  /locations/:id} : get the "id" location.
      *
      * @param id the id of the location to retrieve.
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the location, or with status {@code 404 (Not Found)}.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the location,
+     * or with status {@code 404 (Not Found)}.
      */
     @GetMapping("/locations/{id}")
     public ResponseEntity<Location> getLocation(@PathVariable Long id) {
@@ -116,11 +121,10 @@ public class LocationResource {
     }
 
     @GetMapping("/locations/project/{projectId}")
-    public ResponseEntity<List<Location>> getLocationsByProjectId(@PathVariable Long projectId, Pageable pageable) {
+    public ResponseEntity<List<Location>> getLocationsByProjectId(@PathVariable Long projectId) {
         log.debug("Rest Request to get Locations by projectId {}", projectId);
-        Page<Location> page = locationService.findAllByProjectId(projectId, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return ResponseEntity.ok().headers(headers).body(page.getContent());
+        List<Location> locations = locationService.findAllByProjectId(projectId);
+        return ResponseEntity.ok(locations);
     }
 
     /**


### PR DESCRIPTION
need some help on how to solve this.. given the situation we have the 1 `Location` to n `Section`s.

```postgresql
event_planner=# \d location
                                         Table "public.location"
      Column       |         Type          | Collation | Nullable |               Default
-------------------+-----------------------+-----------+----------+--------------------------------------
 id                | bigint                |           | not null | nextval('location_id_seq'::regclass)
 name              | character varying(50) |           | not null |
 project_id        | bigint                |           | not null |
 responsibility_id | bigint                |           |          |

event_planner=# \d section
                                      Table "public.section"
   Column    |         Type          | Collation | Nullable |               Default
-------------+-----------------------+-----------+----------+-------------------------------------
 id          | bigint                |           | not null | nextval('section_id_seq'::regclass)
 name        | character varying(50) |           | not null |
 location_id | bigint                |           | not null |
Foreign-key constraints:
    "section_location_id_fkey" FOREIGN KEY (location_id) REFERENCES location(id)
```

it's easy to fetch all locations inclusive pagination as we only touch one table and all relations are lazy by default. we haven then x (= the amount of `from location where project_id = :projectId`) return values.

but, we run into a so called "1+n" query problem when fetching locations *and* the corresponding sections. because then we have x * n (= the amount of `location` * the amount of `section where location_id = :locationId`) return values. and thus also a pagination problem, because it is impossible to group it by `location.id`.

there are 3 ways to solve this problem, each with it's up- and downsides:
1. remove pagination entirely, use a simple `@Query` with a join
  * 1 database query
  * pagination no longer possible
  * potential heavy memory use (server and client), x * n entities is a lot
2. use a simple `@Query` with a join, then paginate in-memory
  * 1 database query
  * pagination
  * heavy memory use (server)
3. use the existing paginated query, then fetch `Section`s for each entity
  * 1 + n database queries (at least on first reques)
  * pagination
  * performance improved massively when using `@Cacheable` on `SectionService#findAllByLocationId(Long locationId)`

I tend to the last (3) solution, with an example implementation below (without caching). but am open to your opinions.