### PR TITLE
move authentication JWT into local storage by default

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/security/jwt/TokenProvider.java
+++ b/src/main/java/io/github/bbortt/event/planner/security/jwt/TokenProvider.java
@@ -26,12 +26,14 @@ import org.springframework.util.StringUtils;
 
 @Component
 public class TokenProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(TokenProvider.class);
     private static final String AUTHORITIES_KEY = "auth";
-    private final Logger log = LoggerFactory.getLogger(TokenProvider.class);
+
     private final JHipsterProperties jHipsterProperties;
+
     private Key key;
     private long tokenValidityInMilliseconds;
-    private long tokenValidityInMillisecondsForRememberMe;
 
     public TokenProvider(JHipsterProperties jHipsterProperties) {
         this.jHipsterProperties = jHipsterProperties;
@@ -53,20 +55,13 @@ public class TokenProvider {
         }
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.tokenValidityInMilliseconds = 1000 * jHipsterProperties.getSecurity().getAuthentication().getJwt().getTokenValidityInSeconds();
-        this.tokenValidityInMillisecondsForRememberMe =
-            1000 * jHipsterProperties.getSecurity().getAuthentication().getJwt().getTokenValidityInSecondsForRememberMe();
     }
 
-    public String createToken(Authentication authentication, boolean rememberMe) {
+    public String createToken(Authentication authentication) {
         String authorities = authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(","));
 
         long now = (new Date()).getTime();
-        Date validity;
-        if (rememberMe) {
-            validity = new Date(now + this.tokenValidityInMillisecondsForRememberMe);
-        } else {
-            validity = new Date(now + this.tokenValidityInMilliseconds);
-        }
+        Date validity = new Date(now + this.tokenValidityInMilliseconds);
 
         return Jwts
             .builder()

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/UserJWTController.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/UserJWTController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class UserJWTController {
+
     private final TokenProvider tokenProvider;
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -41,8 +42,7 @@ public class UserJWTController {
 
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        boolean rememberMe = loginVM.isRememberMe() != null && loginVM.isRememberMe();
-        String jwt = tokenProvider.createToken(authentication, rememberMe);
+        String jwt = tokenProvider.createToken(authentication);
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(JWTFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);
         return new ResponseEntity<>(new JWTToken(jwt), httpHeaders, HttpStatus.OK);
@@ -52,6 +52,7 @@ public class UserJWTController {
      * Object to return as body in JWT Authentication.
      */
     static class JWTToken {
+
         private String idToken;
 
         JWTToken(String idToken) {

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/vm/LoginVM.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/vm/LoginVM.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Size;
  * View Model object for storing a user's credentials.
  */
 public class LoginVM {
+
     @NotNull
     @Size(min = 1, max = 50)
     private String username;
@@ -14,8 +15,6 @@ public class LoginVM {
     @NotNull
     @Size(min = 4, max = 100)
     private String password;
-
-    private Boolean rememberMe;
 
     public String getUsername() {
         return username;
@@ -33,20 +32,11 @@ public class LoginVM {
         this.password = password;
     }
 
-    public Boolean isRememberMe() {
-        return rememberMe;
-    }
-
-    public void setRememberMe(Boolean rememberMe) {
-        this.rememberMe = rememberMe;
-    }
-
     // prettier-ignore
     @Override
     public String toString() {
         return "LoginVM{" +
             "username='" + username + '\'' +
-            ", rememberMe=" + rememberMe +
             '}';
     }
 }

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -81,7 +81,6 @@ jhipster:
         base64-secret: Njk4YTYxNjNlNTZmNmY0OTNjOGU1ZWI3NWY1MjI3OGFiODNkYTQyMzJhZmQ1YjJiMDUxNmE2OTcxMmRjZTBjMjY3ZjkyZWUwMjhjMThmMTdjMDU2MjBiYTljMDZkM2NiMjE3ODhlMmMyNTlhZTBlNjEyZDdlMmUyNDhmZTJkMDQ=
         # Token is valid 24 hours
         token-validity-in-seconds: 86400
-        token-validity-in-seconds-for-remember-me: 2592000
   mail: # specific JHipster mail property, for standard properties see MailProperties
     base-url: http://127.0.0.1:8080
   metrics:

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -102,7 +102,6 @@ jhipster:
         base64-secret: ${APPL_JWT_SECURITY_KEY}
         # Token is valid 24 hours
         token-validity-in-seconds: 86400
-        token-validity-in-seconds-for-remember-me: 2592000
   mail:
     base-url: ${APPL_MAIL_BASE_URL}
   metrics:

--- a/src/main/webapp/app/core/auth/auth-jwt.service.ts
+++ b/src/main/webapp/app/core/auth/auth-jwt.service.ts
@@ -16,13 +16,13 @@ export class AuthServerProvider {
   constructor(private http: HttpClient, private $localStorage: LocalStorageService, private $sessionStorage: SessionStorageService) {}
 
   getToken(): string {
-    return this.$localStorage.retrieve('authenticationToken') || this.$sessionStorage.retrieve('authenticationToken') || '';
+    return this.$localStorage.retrieve('authenticationToken') || '';
   }
 
   login(credentials: Login): Observable<void> {
     return this.http
       .post<JwtToken>(SERVER_API_URL + 'api/authenticate', credentials)
-      .pipe(map(response => this.authenticateSuccess(response, credentials.rememberMe)));
+      .pipe(map(response => this.authenticateSuccess(response)));
   }
 
   logout(): Observable<void> {
@@ -33,12 +33,7 @@ export class AuthServerProvider {
     });
   }
 
-  private authenticateSuccess(response: JwtToken, rememberMe: boolean): void {
-    const jwt = response.id_token;
-    if (rememberMe) {
-      this.$localStorage.store('authenticationToken', jwt);
-    } else {
-      this.$sessionStorage.store('authenticationToken', jwt);
-    }
+  private authenticateSuccess(response: JwtToken): void {
+    this.$localStorage.store('authenticationToken', response.id_token);
   }
 }

--- a/src/main/webapp/app/core/login/login.model.ts
+++ b/src/main/webapp/app/core/login/login.model.ts
@@ -1,3 +1,3 @@
 export class Login {
-  constructor(public username: string, public password: string, public rememberMe: boolean) {}
+  constructor(public username: string, public password: string) {}
 }

--- a/src/main/webapp/app/shared/login/login.component.html
+++ b/src/main/webapp/app/shared/login/login.component.html
@@ -28,13 +28,6 @@
                            formControlName="password">
                 </div>
 
-                <div class="form-check">
-                    <label class="form-check-label" for="rememberMe">
-                        <input class="form-check-input" type="checkbox" name="rememberMe" id="rememberMe" formControlName="rememberMe">
-                        <span jhiTranslate="login.form.rememberme">Remember me</span>
-                    </label>
-                </div>
-
                 <button type="submit" class="btn btn-primary" jhiTranslate="login.form.button">Sign in</button>
             </form>
 

--- a/src/main/webapp/app/shared/login/login.component.ts
+++ b/src/main/webapp/app/shared/login/login.component.ts
@@ -18,7 +18,6 @@ export class LoginModalComponent implements AfterViewInit {
   loginForm = this.fb.group({
     username: [''],
     password: [''],
-    rememberMe: [false],
   });
 
   constructor(private loginService: LoginService, private router: Router, public activeModal: NgbActiveModal, private fb: FormBuilder) {}
@@ -43,7 +42,6 @@ export class LoginModalComponent implements AfterViewInit {
       .login({
         username: this.loginForm.get('username')!.value,
         password: this.loginForm.get('password')!.value,
-        rememberMe: this.loginForm.get('rememberMe')!.value,
       })
       .subscribe(
         () => {

--- a/src/main/webapp/i18n/de/login.json
+++ b/src/main/webapp/i18n/de/login.json
@@ -4,7 +4,6 @@
     "form": {
       "password": "Passwort",
       "password.placeholder": "Ihr Passwort",
-      "rememberme": "Automatische Anmeldung",
       "button": "Anmelden"
     },
     "messages": {

--- a/src/main/webapp/i18n/en/login.json
+++ b/src/main/webapp/i18n/en/login.json
@@ -4,7 +4,6 @@
     "form": {
       "password": "Password",
       "password.placeholder": "Your password",
-      "rememberme": "Remember me",
       "button": "Sign in"
     },
     "messages": {

--- a/src/test/java/io/github/bbortt/event/planner/security/jwt/JWTFilterTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/security/jwt/JWTFilterTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class JWTFilterTest {
+
     private TokenProvider tokenProvider;
 
     private JWTFilter jwtFilter;
@@ -47,7 +48,7 @@ public class JWTFilterTest {
             "test-password",
             Collections.singletonList(new SimpleGrantedAuthority(AuthoritiesConstants.USER))
         );
-        String jwt = tokenProvider.createToken(authentication, false);
+        String jwt = tokenProvider.createToken(authentication);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(JWTFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);
         request.setRequestURI("/api/test");
@@ -102,7 +103,7 @@ public class JWTFilterTest {
             "test-password",
             Collections.singletonList(new SimpleGrantedAuthority(AuthoritiesConstants.USER))
         );
-        String jwt = tokenProvider.createToken(authentication, false);
+        String jwt = tokenProvider.createToken(authentication);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(JWTFilter.AUTHORIZATION_HEADER, "Basic " + jwt);
         request.setRequestURI("/api/test");

--- a/src/test/java/io/github/bbortt/event/planner/security/jwt/TokenProviderTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/security/jwt/TokenProviderTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class TokenProviderTest {
+
     private static final long ONE_MINUTE = 60000;
 
     private Key key;
@@ -48,7 +49,7 @@ public class TokenProviderTest {
     @Test
     public void testReturnFalseWhenJWTisMalformed() {
         Authentication authentication = createAuthentication();
-        String token = tokenProvider.createToken(authentication, false);
+        String token = tokenProvider.createToken(authentication);
         String invalidToken = token.substring(1);
         boolean isTokenValid = tokenProvider.validateToken(invalidToken);
 
@@ -60,7 +61,7 @@ public class TokenProviderTest {
         ReflectionTestUtils.setField(tokenProvider, "tokenValidityInMilliseconds", -ONE_MINUTE);
 
         Authentication authentication = createAuthentication();
-        String token = tokenProvider.createToken(authentication, false);
+        String token = tokenProvider.createToken(authentication);
 
         boolean isTokenValid = tokenProvider.validateToken(token);
 

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/UserJWTControllerIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/UserJWTControllerIT.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Integration tests for the {@link UserJWTController} REST controller.
  */
 public class UserJWTControllerIT extends AbstractApplicationContextAwareIT {
+
     @Autowired
     private UserRepository userRepository;
 
@@ -47,30 +48,6 @@ public class UserJWTControllerIT extends AbstractApplicationContextAwareIT {
         LoginVM login = new LoginVM();
         login.setUsername("user-jwt-controller");
         login.setPassword("test");
-        mockMvc
-            .perform(post("/api/authenticate").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(login)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id_token").isString())
-            .andExpect(jsonPath("$.id_token").isNotEmpty())
-            .andExpect(header().string("Authorization", not(nullValue())))
-            .andExpect(header().string("Authorization", not(is(emptyString()))));
-    }
-
-    @Test
-    @Transactional
-    public void testAuthorizeWithRememberMe() throws Exception {
-        User user = new User();
-        user.setLogin("user-jwt-controller-remember-me");
-        user.setEmail("user-jwt-controller-remember-me@example.com");
-        user.setActivated(true);
-        user.setPassword(passwordEncoder.encode("test"));
-
-        userRepository.saveAndFlush(user);
-
-        LoginVM login = new LoginVM();
-        login.setUsername("user-jwt-controller-remember-me");
-        login.setPassword("test");
-        login.setRememberMe(true);
         mockMvc
             .perform(post("/api/authenticate").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(login)))
             .andExpect(status().isOk())

--- a/src/test/javascript/spec/app/shared/login/login.component.spec.ts
+++ b/src/test/javascript/spec/app/shared/login/login.component.spec.ts
@@ -49,13 +49,11 @@ describe('Component Tests', () => {
         const credentials = {
           username: 'admin',
           password: 'admin',
-          rememberMe: true,
         };
 
         comp.loginForm.patchValue({
           username: 'admin',
           password: 'admin',
-          rememberMe: true,
         });
         mockLoginService.setResponse({});
         mockRouter.url = '/admin/metrics';
@@ -81,7 +79,6 @@ describe('Component Tests', () => {
       const expected = {
         username: '',
         password: '',
-        rememberMe: false,
       };
 
       // WHEN
@@ -91,7 +88,6 @@ describe('Component Tests', () => {
       expect(comp.authenticationError).toEqual(false);
       expect(comp.loginForm.get('username')!.value).toEqual(expected.username);
       expect(comp.loginForm.get('password')!.value).toEqual(expected.password);
-      expect(comp.loginForm.get('rememberMe')!.value).toEqual(expected.rememberMe);
       expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('cancel');
     });
 


### PR DESCRIPTION
remove the `remember-me` token. this allows to have multiple tabs with the same session.

> Both LocalStorage and SessionStorage are defined in the same specification and the difference between them is only about the lifetime of the data that is placed on each store. From a security standpoint they are mostly equivalent.