### PR TITLE
load sections as soon as the screenplay was opened.

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    @EntityGraph(attributePaths = { "project", "responsibility", "sections" })
+    @EntityGraph(attributePaths = { "project", "responsibility" })
     List<Location> findAllByProjectId(Long projectId, Sort sort);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    @EntityGraph(attributePaths = { "sections", "responsibility" })
+    @EntityGraph(attributePaths = { "project", "responsibility", "sections" })
     List<Location> findAllByProjectId(Long projectId, Sort sort);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
@@ -1,6 +1,8 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Section;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,6 @@ import org.springframework.stereotype.Repository;
  * Spring Data  repository for the Section entity.
  */
 @Repository
-public interface SectionRepository extends JpaRepository<Section, Long> {}
+public interface SectionRepository extends JpaRepository<Section, Long> {
+    List<Section> findAllByLocationId(Long locationId, Sort sort);
+}

--- a/src/main/java/io/github/bbortt/event/planner/service/SectionService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/SectionService.java
@@ -2,11 +2,13 @@ package io.github.bbortt.event.planner.service;
 
 import io.github.bbortt.event.planner.domain.Section;
 import io.github.bbortt.event.planner.repository.SectionRepository;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,5 +71,11 @@ public class SectionService {
     public void delete(Long id) {
         log.debug("Request to delete Section : {}", id);
         sectionRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Section> findAllByLocationId(Long locationId, Sort sort) {
+        log.debug("Request to get Sections by Location : {}", locationId);
+        return sectionRepository.findAllByLocationId(locationId, sort);
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
@@ -146,7 +146,7 @@ public class LocationResource {
         "\")"
     )
     public ResponseEntity<List<Location>> getLocationsByProjectId(@PathVariable Long projectId, Sort sort) {
-        log.debug("Rest Request to get Locations by projectId {}", projectId);
+        log.debug("REST Request to get Locations by projectId {}", projectId);
         List<Location> locations = locationService.findAllByProjectId(projectId, sort);
         return ResponseEntity.ok(locations);
     }

--- a/src/main/webapp/app/entities/location/location.service.ts
+++ b/src/main/webapp/app/entities/location/location.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { EMPTY, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
 import { createRequestOption } from 'app/shared/util/request-util';
+
 import { Location } from 'app/shared/model/location.model';
 import { Project } from 'app/shared/model/project.model';
-import { Section } from 'app/shared/model/section.model';
+
+import { SERVER_API_URL } from 'app/app.constants';
 
 type EntityResponseType = HttpResponse<Location>;
 type EntityArrayResponseType = HttpResponse<Location[]>;
@@ -44,10 +45,5 @@ export class LocationService {
 
   delete(id: number): Observable<HttpResponse<{}>> {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
-  }
-
-  findAllSections(location: Location): Observable<HttpResponse<Section[]>> {
-    // TODO
-    return EMPTY;
   }
 }

--- a/src/main/webapp/app/entities/section/section.service.ts
+++ b/src/main/webapp/app/entities/section/section.service.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
 import { createRequestOption } from 'app/shared/util/request-util';
+
+import { Location } from 'app/shared/model/location.model';
 import { Section } from 'app/shared/model/section.model';
+
+import { SERVER_API_URL } from 'app/app.constants';
 
 type EntityResponseType = HttpResponse<Section>;
 type EntityArrayResponseType = HttpResponse<Section[]>;
@@ -34,5 +37,13 @@ export class SectionService {
 
   delete(id: number): Observable<HttpResponse<{}>> {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
+  }
+
+  findAllByLocation(location: Location, req?: any): Observable<HttpResponse<Section[]>> {
+    const options = createRequestOption(req);
+    return this.http.get<Location[]>(`${this.resourceUrl}/project/${location.project.id!}/location/${location.id!}`, {
+      params: options,
+      observe: 'response',
+    });
   }
 }

--- a/src/main/webapp/app/view/project/admin/locations/project-locations.component.ts
+++ b/src/main/webapp/app/view/project/admin/locations/project-locations.component.ts
@@ -13,6 +13,7 @@ import { Section } from 'app/shared/model/section.model';
 
 import { ProjectLocationDeleteDialogComponent } from 'app/view/project/admin/locations/project-location-delete-dialog.component';
 import { ProjectSectionDeleteDialogComponent } from 'app/view/project/admin/locations/sections/project-section-delete-dialog.component';
+import { SectionService } from 'app/entities/section/section.service';
 
 @Component({
   selector: 'app-project-locations',
@@ -28,6 +29,7 @@ export class ProjectLocationsComponent implements OnInit, OnDestroy {
 
   constructor(
     protected locationService: LocationService,
+    protected sectionService: SectionService,
     protected activatedRoute: ActivatedRoute,
     protected router: Router,
     protected eventManager: JhiEventManager,
@@ -58,8 +60,15 @@ export class ProjectLocationsComponent implements OnInit, OnDestroy {
   }
 
   private loadLocations(): void {
-    this.locationService.findAllByProject(this.project!, { sort: ['name,asc'] }).subscribe((response: HttpResponse<Location[]>) => {
-      this.loadedLocations = response.body || [];
+    this.locationService.findAllByProject(this.project!, { sort: ['name,asc'] }).subscribe((locations: HttpResponse<Location[]>) => {
+      this.loadedLocations = locations.body || [];
+
+      this.loadedLocations.forEach(location =>
+        this.sectionService
+          .findAllByLocation(location, { sort: ['name,asc'] })
+          .subscribe((sections: HttpResponse<Section[]>) => (location.sections = sections.body || []))
+      );
+
       this.locations = this.loadedLocations;
     });
   }

--- a/src/main/webapp/app/view/project/screenplay/project-screenplay-location.component.ts
+++ b/src/main/webapp/app/view/project/screenplay/project-screenplay-location.component.ts
@@ -1,10 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+
+import { SectionService } from 'app/entities/section/section.service';
 
 import { Location } from 'app/shared/model/location.model';
 import { Section } from 'app/shared/model/section.model';
-
-import { LocationService } from 'app/entities/location/location.service';
-import { HttpResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-project-screenplay-location',
@@ -16,10 +16,10 @@ export class ProjectScreenplayLocationComponent implements OnInit {
 
   sections: Section[] = [];
 
-  constructor(private locationService: LocationService) {}
+  constructor(private sectionService: SectionService) {}
 
   ngOnInit(): void {
-    this.locationService.findAllSections(this.location!).subscribe((response: HttpResponse<Section[]>) => {
+    this.sectionService.findAllByLocation(this.location!, { sort: ['name,asc'] }).subscribe((response: HttpResponse<Section[]>) => {
       this.sections = response.body || [];
     });
   }

--- a/src/main/webapp/app/view/project/screenplay/project-screenplay.component.ts
+++ b/src/main/webapp/app/view/project/screenplay/project-screenplay.component.ts
@@ -36,9 +36,9 @@ export class ProjectScreenplayComponent implements OnInit {
     this.activatedRoute.data.subscribe(({ project }) => {
       this.project = project;
 
-      this.locationService.findAllByProject(this.project!).subscribe((response: HttpResponse<Location[]>) => {
-        this.locations = response.body || [];
-      });
+      this.locationService
+        .findAllByProject(this.project!, { sort: ['name,asc'] })
+        .subscribe((response: HttpResponse<Location[]>) => (this.locations = response.body || []));
     });
 
     this.activatedRoute.queryParams.subscribe((params: Params) => {


### PR DESCRIPTION
PR contains:
* load sections (async) when location (-card) in screenplay has been opened
* load sections async in project-admin location-cards
* backend API endpoint implementation

I think it is an improvement overall because it makes the `location/project/:projectId` response more lightweight. It started to get really big when including the project (which automatically includes it in every child tree too).