### PR TITLE
JHI Message should show name

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/repository/EventRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/EventRepository.java
@@ -5,7 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -28,4 +29,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("select event from Event event left join fetch event.sections where event.id =:id")
     Optional<Event> findOneWithEagerRelationships(@Param("id") Long id);
+
+    @Query("SELECT e.name FROM Event e WHERE e.id = :eventId")
+    Optional<String> findNameByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/LocationRepository.java
@@ -2,10 +2,12 @@ package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Location;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -15,4 +17,7 @@ import org.springframework.stereotype.Repository;
 public interface LocationRepository extends JpaRepository<Location, Long> {
     @EntityGraph(attributePaths = { "project", "responsibility" })
     List<Location> findAllByProjectId(Long projectId, Sort sort);
+
+    @Query("SELECT l.name FROM Location l WHERE l.id = :locationId")
+    Optional<String> findNameByLocationId(@Param("locationId") Long locationId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/ProjectRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/ProjectRepository.java
@@ -1,6 +1,7 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Project;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,4 +28,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
         "    where u.login = :currentUserLogin"
     )
     Page<Project> findMine(@NotNull @Param("currentUserLogin") String currentUserLogin, Pageable pageable);
+
+    @Query("SELECT p.name FROM Project p WHERE p.id = :projectId")
+    Optional<String> findNameByProjectId(@Param("projectId") Long projectId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/ResponsibilityRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/ResponsibilityRepository.java
@@ -2,8 +2,11 @@ package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Responsibility;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -12,4 +15,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ResponsibilityRepository extends JpaRepository<Responsibility, Long> {
     List<Responsibility> findAllByProjectId(Long projectId, Sort sort);
+
+    @Query("SELECT r.name FROM Responsibility r WHERE r.id = :responsibilityId")
+    Optional<String> findNameByResponsibilityId(@Param("responsibilityId") Long responsibilityId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/SectionRepository.java
@@ -2,6 +2,7 @@ package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Section;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,6 +19,9 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
 
     @Query(value = "SELECT s FROM Section s" + "  LEFT JOIN FETCH s.events" + "  WHERE s.location.id = :locationId" + "    ORDER BY s.name")
     List<Section> findAllByLocationIdJoinEventsOrderByNameAsc(@Param("locationId") Long locationId);
+
+    @Query("SELECT s.name FROM Section s WHERE s.id = :sectionId")
+    Optional<String> findNameBySectionId(@Param("sectionId") Long sectionId);
 
     @Modifying
     long deleteAllByLocationId(Long locationId);

--- a/src/main/java/io/github/bbortt/event/planner/service/EventService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/EventService.java
@@ -77,6 +77,18 @@ public class EventService {
     }
 
     /**
+     * Get event name by id.
+     *
+     * @param id the id of the entity.
+     * @return name of the entity.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> findNameByEventId(Long id) {
+        log.debug("Request to get name of Event : {}", id);
+        return eventRepository.findNameByEventId(id);
+    }
+
+    /**
      * Delete the event by id.
      *
      * @param id the id of the entity.

--- a/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
@@ -81,6 +81,18 @@ public class LocationService {
     }
 
     /**
+     * Get location name by id.
+     *
+     * @param id the id of the entity.
+     * @return name of the entity.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> findNameByLocationId(Long id) {
+        log.debug("Request to get name of Location : {}", id);
+        return locationRepository.findNameByLocationId(id);
+    }
+
+    /**
      * Delete the location by id.
      *
      * @param id the id of the entity.
@@ -108,7 +120,7 @@ public class LocationService {
      * Checks if the current user has access to the `Project` linked to the given `Location`, identified by id. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@locationService.hasAccessToLocation(#location, 'ADMIN', 'SECRETARY')")`
      *
      * @param locationId the id of the location with a linked project to check.
-     * @param roles to look out for.
+     * @param roles      to look out for.
      * @return true if the project access has any of the roles.
      */
     @Transactional(readOnly = true)
@@ -126,7 +138,7 @@ public class LocationService {
      * Checks if the current user has access to the `Project` linked to the given `Location`. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@locationService.hasAccessToLocation(#location, 'ADMIN', 'SECRETARY')")`
      *
      * @param location the entity with a linked project to check.
-     * @param roles to look out for.
+     * @param roles    to look out for.
      * @return true if the project access has any of the roles.
      */
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/io/github/bbortt/event/planner/service/ProjectService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/ProjectService.java
@@ -13,7 +13,6 @@ import io.github.bbortt.event.planner.service.dto.CreateProjectDTO;
 import io.github.bbortt.event.planner.service.dto.UserDTO;
 import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.service.exception.IdMustBePresentException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -102,6 +101,18 @@ public class ProjectService {
     public Optional<Project> findOne(Long id) {
         log.debug("Request to get Project : {}", id);
         return projectRepository.findById(id);
+    }
+
+    /**
+     * Get project name by id.
+     *
+     * @param id the id of the entity.
+     * @return name of the entity.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> findNameByProjectId(Long id) {
+        log.debug("Request to get name of Project : {}", id);
+        return projectRepository.findNameByProjectId(id);
     }
 
     /**

--- a/src/main/java/io/github/bbortt/event/planner/service/ResponsibilityService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/ResponsibilityService.java
@@ -1,14 +1,9 @@
 package io.github.bbortt.event.planner.service;
 
 import io.github.bbortt.event.planner.domain.Responsibility;
-import io.github.bbortt.event.planner.repository.ProjectRepository;
 import io.github.bbortt.event.planner.repository.ResponsibilityRepository;
-import io.github.bbortt.event.planner.repository.RoleRepository;
-import io.github.bbortt.event.planner.security.AuthoritiesConstants;
-import io.github.bbortt.event.planner.security.SecurityUtils;
 import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.service.exception.IdMustBePresentException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -76,6 +71,18 @@ public class ResponsibilityService {
     }
 
     /**
+     * Get responsibility name by id.
+     *
+     * @param id the id of the entity.
+     * @return name of the entity.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> findNameByResponsibilityId(Long id) {
+        log.debug("Request to get name of Responsibility : {}", id);
+        return responsibilityRepository.findNameByResponsibilityId(id);
+    }
+
+    /**
      * Delete the responsibility by id.
      *
      * @param id the id of the entity.
@@ -105,7 +112,7 @@ public class ResponsibilityService {
      * Checks if the current user has access to the `Project` linked to the given `Responsibility`, identified by id. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@responsibilityService.hasAccessToResponsibility(#responsibility, 'ADMIN', 'SECRETARY')")`
      *
      * @param responsibilityId the id of the responsibility with a linked project to check.
-     * @param roles to look out for.
+     * @param roles            to look out for.
      * @return true if the project access has any of the roles.
      */
     @Transactional(readOnly = true)
@@ -123,7 +130,7 @@ public class ResponsibilityService {
      * Checks if the current user has access to the `Project` linked to the given `Responsibility`. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@responsibilityService.hasAccessToResponsibility(#responsibility, 'ADMIN', 'SECRETARY')")`
      *
      * @param responsibility the entity with a linked project to check.
-     * @param roles to look out for.
+     * @param roles          to look out for.
      * @return true if the project access has any of the roles.
      */
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/io/github/bbortt/event/planner/service/SectionService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/SectionService.java
@@ -67,7 +67,7 @@ public class SectionService {
      * Get all sections for the given location.
      *
      * @param locationId the location to retrieve sections for.
-     * @param sort the sorting.
+     * @param sort       the sorting.
      * @return the list of entities.
      */
     @Transactional(readOnly = true)
@@ -101,6 +101,18 @@ public class SectionService {
     }
 
     /**
+     * Get section name by id.
+     *
+     * @param id the id of the entity.
+     * @return name of the entity.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> findNamebySectionId(Long id) {
+        log.debug("Request to get name of Section : {}", id);
+        return sectionRepository.findNameBySectionId(id);
+    }
+
+    /**
      * Delete the section by id.
      *
      * @param id the id of the entity.
@@ -115,7 +127,7 @@ public class SectionService {
      * Checks if the current user has access to the `Project` linked to the given `Section`, identified by id. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@sectionService.hasAccessToSection(#location, 'ADMIN', 'SECRETARY')")`
      *
      * @param sectionId the id of the location with a linked project to check.
-     * @param roles to look out for.
+     * @param roles     to look out for.
      * @return true if the project access has any of the roles.
      */
     @Transactional(readOnly = true)
@@ -133,7 +145,7 @@ public class SectionService {
      * Checks if the current user has access to the `Project` linked to the given `Section`. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@sectionService.hasAccessToSection(#location, 'ADMIN', 'SECRETARY')")`
      *
      * @param section the entity with a linked project to check.
-     * @param roles to look out for.
+     * @param roles   to look out for.
      * @return true if the project access has any of the roles.
      */
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/EventResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/EventResource.java
@@ -2,6 +2,7 @@ package io.github.bbortt.event.planner.web.rest;
 
 import io.github.bbortt.event.planner.domain.Event;
 import io.github.bbortt.event.planner.service.EventService;
+import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.web.rest.errors.BadRequestAlertException;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
@@ -17,9 +18,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
@@ -28,6 +36,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequestMapping("/api")
 public class EventResource {
+
     private final Logger log = LoggerFactory.getLogger(EventResource.class);
 
     private static final String ENTITY_NAME = "event";
@@ -57,7 +66,7 @@ public class EventResource {
         Event result = eventService.save(event);
         return ResponseEntity
             .created(new URI("/api/events/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getName()))
             .body(result);
     }
 
@@ -65,9 +74,7 @@ public class EventResource {
      * {@code PUT  /events} : Updates an existing event.
      *
      * @param event the event to update.
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated event,
-     * or with status {@code 400 (Bad Request)} if the event is not valid,
-     * or with status {@code 500 (Internal Server Error)} if the event couldn't be updated.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated event, or with status {@code 400 (Bad Request)} if the event is not valid, or with status {@code 500 (Internal Server Error)} if the event couldn't be updated.
      * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/events")
@@ -79,14 +86,14 @@ public class EventResource {
         Event result = eventService.save(event);
         return ResponseEntity
             .ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, event.getId().toString()))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, event.getName()))
             .body(result);
     }
 
     /**
      * {@code GET  /events} : get all the events.
      *
-     * @param pageable the pagination information.
+     * @param pageable  the pagination information.
      * @param eagerload flag to eager load entities from relationships (This is applicable for many-to-many).
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of events in body.
      */
@@ -128,10 +135,11 @@ public class EventResource {
     @DeleteMapping("/events/{id}")
     public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
         log.debug("REST request to delete Event : {}", id);
+        Event event = eventService.findOne(id).orElseThrow(EntityNotFoundException::new);
         eventService.delete(id);
         return ResponseEntity
             .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, event.getName()))
             .build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/EventResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/EventResource.java
@@ -135,11 +135,8 @@ public class EventResource {
     @DeleteMapping("/events/{id}")
     public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
         log.debug("REST request to delete Event : {}", id);
-        Event event = eventService.findOne(id).orElseThrow(EntityNotFoundException::new);
+        String name = eventService.findNameByEventId(id).orElseThrow(EntityNotFoundException::new);
         eventService.delete(id);
-        return ResponseEntity
-            .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, event.getName()))
-            .build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name)).build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
@@ -5,6 +5,7 @@ import io.github.bbortt.event.planner.security.AuthoritiesConstants;
 import io.github.bbortt.event.planner.security.RolesConstants;
 import io.github.bbortt.event.planner.service.LocationService;
 import io.github.bbortt.event.planner.service.ProjectService;
+import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.web.rest.errors.BadRequestAlertException;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
@@ -72,7 +73,7 @@ public class LocationResource {
         Location result = locationService.save(location);
         return ResponseEntity
             .created(new URI("/api/locations/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getName()))
             .body(result);
     }
 
@@ -93,7 +94,7 @@ public class LocationResource {
         Location result = locationService.save(location);
         return ResponseEntity
             .ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, location.getId().toString()))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, location.getName()))
             .body(result);
     }
 
@@ -130,7 +131,7 @@ public class LocationResource {
      * {@code GET /locations/project/:projectId} : get all Locations by project id.
      *
      * @param projectId the id of the project.
-     * @param sort optional sort of locations
+     * @param sort      optional sort of locations
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the location, or with status {@code 404 (Not Found)}.
      */
     @GetMapping("/locations/project/{projectId}")
@@ -161,10 +162,11 @@ public class LocationResource {
     @PreAuthorize("@locationService.hasAccessToLocation(#id, \"" + RolesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteLocation(@PathVariable Long id) {
         log.debug("REST request to delete Location : {}", id);
+        Location location = locationService.findOne(id).orElseThrow(EntityNotFoundException::new);
         locationService.delete(id);
         return ResponseEntity
             .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, location.getName()))
             .build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/LocationResource.java
@@ -162,11 +162,8 @@ public class LocationResource {
     @PreAuthorize("@locationService.hasAccessToLocation(#id, \"" + RolesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteLocation(@PathVariable Long id) {
         log.debug("REST request to delete Location : {}", id);
-        Location location = locationService.findOne(id).orElseThrow(EntityNotFoundException::new);
+        String name = locationService.findNameByLocationId(id).orElseThrow(EntityNotFoundException::new);
         locationService.delete(id);
-        return ResponseEntity
-            .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, location.getName()))
-            .build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name)).build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/ProjectResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/ProjectResource.java
@@ -5,6 +5,7 @@ import io.github.bbortt.event.planner.security.AuthoritiesConstants;
 import io.github.bbortt.event.planner.security.RolesConstants;
 import io.github.bbortt.event.planner.service.ProjectService;
 import io.github.bbortt.event.planner.service.dto.CreateProjectDTO;
+import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.web.rest.errors.BadRequestAlertException;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
@@ -67,7 +68,7 @@ public class ProjectResource {
         Project result = projectService.create(createProjectDTO);
         return ResponseEntity
             .created(new URI("/api/projects/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getName()))
             .body(result);
     }
 
@@ -88,14 +89,14 @@ public class ProjectResource {
         Project result = projectService.save(project);
         return ResponseEntity
             .ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, project.getId().toString()))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, project.getName()))
             .body(result);
     }
 
     /**
      * {@code GET  /projects} : get all the projects.
      *
-     * @param loadAll loads projects for current user by default.
+     * @param loadAll  loads projects for current user by default.
      * @param pageable the pagination information.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of projects in body.
      */
@@ -146,10 +147,11 @@ public class ProjectResource {
     @PreAuthorize("hasAnyRole(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
         log.debug("REST request to delete Project : {}", id);
+        Project project = projectService.findOne(id).orElseThrow(EntityNotFoundException::new);
         projectService.delete(id);
         return ResponseEntity
             .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, project.getName()))
             .build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/ProjectResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/ProjectResource.java
@@ -147,11 +147,8 @@ public class ProjectResource {
     @PreAuthorize("hasAnyRole(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
         log.debug("REST request to delete Project : {}", id);
-        Project project = projectService.findOne(id).orElseThrow(EntityNotFoundException::new);
+        String name = projectService.findNameByProjectId(id).orElseThrow(EntityNotFoundException::new);
         projectService.delete(id);
-        return ResponseEntity
-            .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, project.getName()))
-            .build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name)).build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResource.java
@@ -159,11 +159,8 @@ public class ResponsibilityResource {
     )
     public ResponseEntity<Void> deleteResponsibility(@PathVariable Long id) {
         log.debug("REST request to delete Responsibility : {}", id);
-        Responsibility responsibility = responsibilityService.findOne(id).orElseThrow(EntityNotFoundException::new);
+        String name = responsibilityService.findNameByResponsibilityId(id).orElseThrow(EntityNotFoundException::new);
         responsibilityService.delete(id);
-        return ResponseEntity
-            .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, responsibility.getName()))
-            .build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name)).build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/ResponsibilityResource.java
@@ -4,6 +4,7 @@ import io.github.bbortt.event.planner.domain.Responsibility;
 import io.github.bbortt.event.planner.security.AuthoritiesConstants;
 import io.github.bbortt.event.planner.security.RolesConstants;
 import io.github.bbortt.event.planner.service.ResponsibilityService;
+import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.web.rest.errors.BadRequestAlertException;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
@@ -76,7 +77,7 @@ public class ResponsibilityResource {
         Responsibility result = responsibilityService.save(responsibility);
         return ResponseEntity
             .created(new URI("/api/responsibilities/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getName()))
             .body(result);
     }
 
@@ -104,7 +105,7 @@ public class ResponsibilityResource {
         Responsibility result = responsibilityService.save(responsibility);
         return ResponseEntity
             .ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, responsibility.getId().toString()))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, responsibility.getName()))
             .body(result);
     }
 
@@ -158,10 +159,11 @@ public class ResponsibilityResource {
     )
     public ResponseEntity<Void> deleteResponsibility(@PathVariable Long id) {
         log.debug("REST request to delete Responsibility : {}", id);
+        Responsibility responsibility = responsibilityService.findOne(id).orElseThrow(EntityNotFoundException::new);
         responsibilityService.delete(id);
         return ResponseEntity
             .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, responsibility.getName()))
             .build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/SectionResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/SectionResource.java
@@ -163,11 +163,8 @@ public class SectionResource {
     @PreAuthorize("@sectionService.hasAccessToSection(#id, \"" + RolesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteSection(@PathVariable Long id) {
         log.debug("REST request to delete Section : {}", id);
-        Section section = sectionService.findOne(id).orElseThrow(EntityNotFoundException::new);
+        String name = sectionService.findNamebySectionId(id).orElseThrow(EntityNotFoundException::new);
         sectionService.delete(id);
-        return ResponseEntity
-            .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, section.getName()))
-            .build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name)).build();
     }
 }

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/SectionResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/SectionResource.java
@@ -5,6 +5,7 @@ import io.github.bbortt.event.planner.security.AuthoritiesConstants;
 import io.github.bbortt.event.planner.security.RolesConstants;
 import io.github.bbortt.event.planner.service.ProjectService;
 import io.github.bbortt.event.planner.service.SectionService;
+import io.github.bbortt.event.planner.service.exception.EntityNotFoundException;
 import io.github.bbortt.event.planner.web.rest.errors.BadRequestAlertException;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
@@ -72,7 +73,7 @@ public class SectionResource {
         Section result = sectionService.save(section);
         return ResponseEntity
             .created(new URI("/api/sections/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getName()))
             .body(result);
     }
 
@@ -93,7 +94,7 @@ public class SectionResource {
         Section result = sectionService.save(section);
         return ResponseEntity
             .ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, section.getId().toString()))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, section.getName()))
             .body(result);
     }
 
@@ -162,10 +163,11 @@ public class SectionResource {
     @PreAuthorize("@sectionService.hasAccessToSection(#id, \"" + RolesConstants.ADMIN + "\")")
     public ResponseEntity<Void> deleteSection(@PathVariable Long id) {
         log.debug("REST request to delete Section : {}", id);
+        Section section = sectionService.findOne(id).orElseThrow(EntityNotFoundException::new);
         sectionService.delete(id);
         return ResponseEntity
             .noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, section.getName()))
             .build();
     }
 }

--- a/src/main/webapp/i18n/de/event.json
+++ b/src/main/webapp/i18n/de/event.json
@@ -7,11 +7,11 @@
         "createOrEditLabel": "Ereignis erstellen oder bearbeiten",
         "notFound": "Keine Ereignise gefunden"
       },
-      "created": "Ereignis mit ID {{ param }} erstellt",
-      "updated": "Ereignis mit ID {{ param }} aktualisiert",
-      "deleted": "Ereignis mit ID {{ param }} gelöscht",
+      "created": "Ereignis {{ param }} erstellt",
+      "updated": "Ereignis {{ param }} aktualisiert",
+      "deleted": "Ereignis {{ param }} gelöscht",
       "delete": {
-        "question": "Soll Ereignis {{ id }} wirklich dauerhaft gelöscht werden?"
+        "question": "Soll Ereignis {{ name }} wirklich dauerhaft gelöscht werden?"
       },
       "detail": {
         "title": "Ereignis"

--- a/src/main/webapp/i18n/de/location.json
+++ b/src/main/webapp/i18n/de/location.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Lokalität erstellen oder bearbeiten",
         "notFound": "Keine Lokalitäten gefunden"
       },
-      "created": "Lokalität mit ID {{ param }} erstellt",
-      "updated": "Lokalität mit ID {{ param }} aktualisiert",
-      "deleted": "Lokalität mit ID {{ param }} gelöscht",
+      "created": "Lokalität {{ param }} erstellt",
+      "updated": "Lokalität {{ param }} aktualisiert",
+      "deleted": "Lokalität {{ param }} gelöscht",
       "delete": {
         "question": "Soll Lokalität {{ name }} wirklich dauerhaft gelöscht werden?",
         "warning": "Dies wird alle untergeordneten Abschnitte und Ereignise löschen!"

--- a/src/main/webapp/i18n/de/project.json
+++ b/src/main/webapp/i18n/de/project.json
@@ -16,11 +16,11 @@
         "noDescription": "Projekt hat keine Beschreibung.",
         "loadMore": "Mehr Projekte Laden"
       },
-      "created": "Projekt mit ID {{ param }} erstellt",
-      "updated": "Projekt mit ID {{ param }} aktualisiert",
-      "deleted": "Projekt mit ID {{ param }} gelöscht",
+      "created": "Projekt {{ param }} erstellt",
+      "updated": "Projekt {{ param }} aktualisiert",
+      "deleted": "Projekt {{ param }} gelöscht",
       "delete": {
-        "question": "Soll Projekt {{ id }} wirklich dauerhaft gelöscht werden?"
+        "question": "Soll Projekt {{ name }} wirklich dauerhaft gelöscht werden?"
       },
       "detail": {
         "title": "Projekt"

--- a/src/main/webapp/i18n/de/responsibility.json
+++ b/src/main/webapp/i18n/de/responsibility.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Verantwortlichkeit erstellen oder bearbeiten",
         "notFound": "Keine Verantwortlichkeiten gefunden"
       },
-      "created": "Verantwortlichkeit mit ID {{ param }} erstellt",
-      "updated": "Verantwortlichkeit mit ID {{ param }} aktualisiert",
-      "deleted": "Verantwortlichkeit mit ID {{ param }} gelöscht",
+      "created": "Verantwortlichkeit {{ param }} erstellt",
+      "updated": "Verantwortlichkeit {{ param }} aktualisiert",
+      "deleted": "Verantwortlichkeit {{ param }} gelöscht",
       "delete": {
         "question": "Soll Verantwortlichkeit {{ name }} wirklich dauerhaft gelöscht werden?"
       },

--- a/src/main/webapp/i18n/de/section.json
+++ b/src/main/webapp/i18n/de/section.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Abschnitt erstellen oder bearbeiten",
         "notFound": "Keine Abschnitte gefunden"
       },
-      "created": "Abschnitt mit ID {{ param }} erstellt",
-      "updated": "Abschnitt mit ID {{ param }} aktualisiert",
-      "deleted": "Abschnitt mit ID {{ param }} gelöscht",
+      "created": "Abschnitt {{ param }} erstellt",
+      "updated": "Abschnitt {{ param }} aktualisiert",
+      "deleted": "Abschnitt {{ param }} gelöscht",
       "delete": {
         "question": "Soll Abschnitt {{ name }} wirklich dauerhaft gelöscht werden?",
         "warning": "Dies wird alle untergeordneten Ereignise löschen!"

--- a/src/main/webapp/i18n/en/event.json
+++ b/src/main/webapp/i18n/en/event.json
@@ -7,11 +7,11 @@
         "createOrEditLabel": "Create or edit a Event",
         "notFound": "No Events found"
       },
-      "created": "A new Event is created with identifier {{ param }}",
-      "updated": "A Event is updated with identifier {{ param }}",
-      "deleted": "A Event is deleted with identifier {{ param }}",
+      "created": "New Event {{ param }} is created",
+      "updated": "Event {{ param }} is updated",
+      "deleted": "Event {{ param }} is deleted",
       "delete": {
-        "question": "Are you sure you want to delete Event {{ id }}?"
+        "question": "Are you sure you want to delete Event {{ name }}?"
       },
       "detail": {
         "title": "Event"

--- a/src/main/webapp/i18n/en/event.json
+++ b/src/main/webapp/i18n/en/event.json
@@ -7,9 +7,9 @@
         "createOrEditLabel": "Create or edit a Event",
         "notFound": "No Events found"
       },
-      "created": "New Event {{ param }} is created",
-      "updated": "Event {{ param }} is updated",
-      "deleted": "Event {{ param }} is deleted",
+      "created": "New Event {{ param }} was created",
+      "updated": "Event {{ param }} was updated",
+      "deleted": "Event {{ param }} was deleted",
       "delete": {
         "question": "Are you sure you want to delete Event {{ name }}?"
       },

--- a/src/main/webapp/i18n/en/location.json
+++ b/src/main/webapp/i18n/en/location.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Location",
         "notFound": "No Locations found"
       },
-      "created": "A new Location is created with identifier {{ param }}",
-      "updated": "A Location is updated with identifier {{ param }}",
-      "deleted": "A Location is deleted with identifier {{ param }}",
+      "created": "New Location {{ param }} is created",
+      "updated": "Location {{ param }} is updated",
+      "deleted": "Location {{ param }} is deleted",
       "delete": {
         "question": "Are you sure you want to delete Location {{ name }}?",
         "warning": "This will delete all Sections and Events contained!"

--- a/src/main/webapp/i18n/en/location.json
+++ b/src/main/webapp/i18n/en/location.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Location",
         "notFound": "No Locations found"
       },
-      "created": "New Location {{ param }} is created",
-      "updated": "Location {{ param }} is updated",
-      "deleted": "Location {{ param }} is deleted",
+      "created": "New Location {{ param }} was created",
+      "updated": "Location {{ param }} was updated",
+      "deleted": "Location {{ param }} was deleted",
       "delete": {
         "question": "Are you sure you want to delete Location {{ name }}?",
         "warning": "This will delete all Sections and Events contained!"

--- a/src/main/webapp/i18n/en/project.json
+++ b/src/main/webapp/i18n/en/project.json
@@ -16,9 +16,9 @@
         "noDescription": "Project does not have a description.",
         "loadMore": "Load more projects"
       },
-      "created": "New Project {{ param }} is created",
-      "updated": "Project {{ param }} is updated",
-      "deleted": "Project {{ param }} is deleted",
+      "created": "New Project {{ param }} was created",
+      "updated": "Project {{ param }} was updated",
+      "deleted": "Project {{ param }} was deleted",
       "delete": {
         "question": "Are you sure you want to delete Project {{ name }}?"
       },

--- a/src/main/webapp/i18n/en/project.json
+++ b/src/main/webapp/i18n/en/project.json
@@ -16,11 +16,11 @@
         "noDescription": "Project does not have a description.",
         "loadMore": "Load more projects"
       },
-      "created": "A new Project is created with identifier {{ param }}",
-      "updated": "A Project is updated with identifier {{ param }}",
-      "deleted": "A Project is deleted with identifier {{ param }}",
+      "created": "New Project {{ param }} is created",
+      "updated": "Project {{ param }} is updated",
+      "deleted": "Project {{ param }} is deleted",
       "delete": {
-        "question": "Are you sure you want to delete Project {{ id }}?"
+        "question": "Are you sure you want to delete Project {{ name }}?"
       },
       "detail": {
         "title": "Project"

--- a/src/main/webapp/i18n/en/responsibility.json
+++ b/src/main/webapp/i18n/en/responsibility.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Responsibility",
         "notFound": "No Responsibilities found"
       },
-      "created": "A new Responsibility is created with identifier {{ param }}",
-      "updated": "A Responsibility is updated with identifier {{ param }}",
-      "deleted": "A Responsibility is deleted with identifier {{ param }}",
+      "created": "New Responsibility {{ param }} is created",
+      "updated": "Responsibility {{ param }} is updated",
+      "deleted": "Responsibility {{ param }} is deleted",
       "delete": {
         "question": "Are you sure you want to delete Responsibility {{ name }}?"
       },

--- a/src/main/webapp/i18n/en/responsibility.json
+++ b/src/main/webapp/i18n/en/responsibility.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Responsibility",
         "notFound": "No Responsibilities found"
       },
-      "created": "New Responsibility {{ param }} is created",
-      "updated": "Responsibility {{ param }} is updated",
-      "deleted": "Responsibility {{ param }} is deleted",
+      "created": "New Responsibility {{ param }} was created",
+      "updated": "Responsibility {{ param }} was updated",
+      "deleted": "Responsibility {{ param }} was deleted",
       "delete": {
         "question": "Are you sure you want to delete Responsibility {{ name }}?"
       },

--- a/src/main/webapp/i18n/en/section.json
+++ b/src/main/webapp/i18n/en/section.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Section",
         "notFound": "No Sections found"
       },
-      "created": "New Section {{ param }} is created",
-      "updated": "Section {{ param }} is updated",
-      "deleted": "Section {{ param }} is deleted",
+      "created": "New Section {{ param }} was created",
+      "updated": "Section {{ param }} was updated",
+      "deleted": "Section {{ param }} was deleted",
       "delete": {
         "question": "Are you sure you want to delete Section {{ name }}?",
         "warning": "This will delete all Events contained!"

--- a/src/main/webapp/i18n/en/section.json
+++ b/src/main/webapp/i18n/en/section.json
@@ -8,9 +8,9 @@
         "createOrEditLabel": "Create or edit a Section",
         "notFound": "No Sections found"
       },
-      "created": "A new Section is created with identifier {{ param }}",
-      "updated": "A Section is updated with identifier {{ param }}",
-      "deleted": "A Section is deleted with identifier {{ param }}",
+      "created": "New Section {{ param }} is created",
+      "updated": "Section {{ param }} is updated",
+      "deleted": "Section {{ param }} is deleted",
       "delete": {
         "question": "Are you sure you want to delete Section {{ name }}?",
         "warning": "This will delete all Events contained!"


### PR DESCRIPTION
Löst Issue #92 

Habe beim löschen jeweils die Klasse suchen müssen um den Namen zu erhalten. Gäbe es auch einen effizienteren Weg?
Macht es einen Unterschied der Performance zwischen
```
Responsibility` responsibility = responsibilityService.findOne(id).orElseThrow(EntityNotFoundException::new);
.headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, responsibility.getName()))
```
und
```
String name = responsibilityService.findOne(id).orElseThrow(EntityNotFoundException::new).getName();
.headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, name))
```
