### PR TITLE
change jhi_user password column definition to char.

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/domain/User.java
+++ b/src/main/java/io/github/bbortt/event/planner/domain/User.java
@@ -55,7 +55,7 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @NotNull
     @JsonIgnore
     @Size(min = 60, max = 60)
-    @Column(name = "password_hash", length = 60, nullable = false)
+    @Column(name = "password_hash", length = 60, nullable = false, columnDefinition = "bpchar(60)")
     private String password;
 
     @Size(max = 50)

--- a/src/main/resources/db/migration/V2021.01.06.17.20__update_jhi_user_password.sql
+++ b/src/main/resources/db/migration/V2021.01.06.17.20__update_jhi_user_password.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jhi_user
+    ALTER COLUMN password_hash TYPE CHAR(60);


### PR DESCRIPTION
a bcrypted password hash will always have a length of 60 characters. there is no need to use `CHARACTER VARYING` in `jhi_user`.