### PR TITLE
Bugfix/#162 enhanced invitation security

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/domain/Invitation.java
+++ b/src/main/java/io/github/bbortt/event/planner/domain/Invitation.java
@@ -23,9 +23,12 @@ import org.hibernate.annotations.Parameter;
 @Entity
 @Table(
     name = "invitation",
-    uniqueConstraints = { @UniqueConstraint(name = "unique_invitation_per_project", columnNames = { "email", "project_id" }) }
+    uniqueConstraints = {
+        @UniqueConstraint(name = "unique_invitation_per_project", columnNames = { "email", "project_id" }),
+        @UniqueConstraint(name = "unique_user_per_project", columnNames = { "jhi_user_id", "project_id" }),
+    }
 )
-public class Invitation implements Serializable {
+public class Invitation extends AbstractAuditingEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
@@ -28,5 +28,5 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
     Optional<Invitation> findOnyByEmailAndProjectId(String email, Long projectId);
 
-    List<Invitation> findAllByAcceptedIsFalseAndAndTokenIsNotNullAndCreatedDateBefore(Instant dateTime);
+    List<Invitation> findAllByAcceptedIsFalseAndTokenIsNotNullAndCreatedDateBefore(Instant dateTime);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
@@ -1,7 +1,6 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Invitation;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,4 +22,6 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     void assignUserToInvitation(@Param("userId") Long userId, @Param("token") String token);
 
     Optional<Invitation> findByToken(String token);
+
+    Optional<Invitation> findOnyByEmailAndProjectId(String email, Long projectId);
 }

--- a/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
@@ -1,6 +1,9 @@
 package io.github.bbortt.event.planner.repository;
 
 import io.github.bbortt.event.planner.domain.Invitation;
+import io.github.bbortt.event.planner.domain.User;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,4 +27,6 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     Optional<Invitation> findByToken(String token);
 
     Optional<Invitation> findOnyByEmailAndProjectId(String email, Long projectId);
+
+    List<Invitation> findAllByAcceptedIsFalseAndAndTokenIsNotNullAndCreatedDateBefore(Instant dateTime);
 }

--- a/src/main/java/io/github/bbortt/event/planner/service/InvitationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/InvitationService.java
@@ -157,7 +157,7 @@ public class InvitationService {
     @Scheduled(cron = "0 0 1 * * ?")
     public void removeNotAcceptedInvitations() {
         invitationRepository
-            .findAllByAcceptedIsFalseAndAndTokenIsNotNullAndCreatedDateBefore(Instant.now().minus(14, ChronoUnit.DAYS))
+            .findAllByAcceptedIsFalseAndTokenIsNotNullAndCreatedDateBefore(Instant.now().minus(14, ChronoUnit.DAYS))
             .forEach(
                 invitation -> {
                     log.debug("Deleting not accepted invitation {} in project {}", invitation.getEmail(), invitation.getProject().getId());

--- a/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/LocationService.java
@@ -149,7 +149,7 @@ public class LocationService {
     }
 
     /**
-     * Checks if the current user has access to the `Project` linked to the given `Location`, identified by id. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@locationService.hasAccessToLocation(#location, 'ADMIN', 'SECRETARY')")`
+     * Checks if the current user has access to the `Project` linked to the given `Location`, identified by id. The project access must be given by any of the `roles`. Example usage: `@PreAuthorize("@locationService.hasAccessToLocation(#locationId, 'ADMIN', 'SECRETARY')")`
      *
      * @param locationId the id of the location with a linked project to check.
      * @param roles to look out for.

--- a/src/main/java/io/github/bbortt/event/planner/service/UserService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/UserService.java
@@ -299,7 +299,6 @@ public class UserService {
 
     /**
      * Not activated users should be automatically deleted after 3 days.
-     * <p>
      * This is scheduled to get fired everyday, at 01:00 (am).
      */
     @Transactional

--- a/src/main/resources/db/migration/V2021.01.16.10.00__invitation_security.sql
+++ b/src/main/resources/db/migration/V2021.01.16.10.00__invitation_security.sql
@@ -1,0 +1,10 @@
+ALTER TABLE INVITATION
+    ADD COLUMN created_by         CHARACTER VARYING(50) NOT NULL DEFAULT 'anonymousUser',
+    ADD COLUMN created_date       TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN reset_date         TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN last_modified_by   CHARACTER VARYING(50),
+    ADD COLUMN last_modified_date TIMESTAMP WITH TIME ZONE,
+    ADD CONSTRAINT unique_user_per_project UNIQUE (jhi_user_id, project_id);
+
+ALTER TABLE invitation
+    ALTER COLUMN created_by DROP DEFAULT;

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -30,3 +30,4 @@ email.reset.text2=Best regards,
 email.invitation.title=Event-Planner invitation
 email.invitation.text1=You have been invited to join project {0}.
 email.invitation.accept=Accept Invitation
+email.invitation.validity=The link will be valid for 14 days.

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -26,6 +26,8 @@ email.reset.text1=Für deinen Event-Planer Account wurde ein neues Passwort ange
 email.reset.reset=Jetzt zurücksetzen!
 email.reset.text2=Beste Grüsse,
 
+# Invitation email
 email.invitation.title=Event-Planner Einladung
 email.invitation.text1=Sie wurden eingeladen, dem Projekt {0} beizutreten.
 email.invitation.accept=Einladung akzeptieren
+email.invitation.validity=Der Link ist für 14 Tage gültig.

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -30,3 +30,4 @@ email.reset.text2=Best regards,
 email.invitation.title=Event-Planner invitation
 email.invitation.text1=You have been invited to join project {0}.
 email.invitation.accept=Accept Invitation
+email.invitation.validity=The link will be valid for 14 days.

--- a/src/main/resources/templates/mail/invitationEmail.html
+++ b/src/main/resources/templates/mail/invitationEmail.html
@@ -27,6 +27,9 @@
             </button>
         </p>
         <p>
+            <span th:text="#{email.activation.validity}">The link will be valid for 14 days.</span>
+        </p>
+        <p>
             <span th:text="#{email.activation.text2}">Best regards, </span>
             <br/>
             <em th:text="#{email.signature}">Event-Planner.</em>

--- a/src/main/webapp/app/entities/invitation/invitation.service.ts
+++ b/src/main/webapp/app/entities/invitation/invitation.service.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { Invitation } from 'app/shared/model/invitation.model';
+import { Project } from 'app/shared/model/project.model';
 
 import { createRequestOption } from 'app/shared/util/request-util';
 
@@ -54,5 +55,9 @@ export class InvitationService {
 
   checkTokenValidity(token: string): Observable<boolean> {
     return this.http.post<boolean>(`${this.resourceUrl}/token-validity`, token);
+  }
+
+  emailExistsInProject(project: Project, email: string): Observable<boolean> {
+    return this.http.post<boolean>(`${this.resourceUrl}/project/${project.id!}/email-exists`, email);
   }
 }

--- a/src/main/webapp/app/view/project/admin/users/project-user-invite.component.html
+++ b/src/main/webapp/app/view/project/admin/users/project-user-invite.component.html
@@ -27,7 +27,7 @@
                                jhiTranslate="entity.validation.required">
                         </small>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('name')?.errors?.exists"
+                               *ngIf="editForm.get('email')?.errors?.exists"
                                jhiTranslate="entity.validation.uniqueness"
                                [translateValues]="{ max: 50 }">
                             This value has already been taken.

--- a/src/main/webapp/app/view/project/admin/users/project-user-invite.component.html
+++ b/src/main/webapp/app/view/project/admin/users/project-user-invite.component.html
@@ -1,6 +1,6 @@
 <div class="row justify-content-center">
     <div class="col-8">
-        <form name="inviteForm" role="form" novalidate (ngSubmit)="save()" [formGroup]="inviteForm">
+        <form name="inviteForm" role="form" novalidate (ngSubmit)="save()" [formGroup]="editForm">
             <h2 id="jhi-project-heading" jhiTranslate="userManagement.invite"></h2>
 
             <div>
@@ -17,14 +17,20 @@
                            [readOnly]="!isNew"
                     />
                     <div
-                        *ngIf="inviteForm.get('email')!.invalid && inviteForm.get('email')!.dirty || inviteForm.get('email')!.touched">
+                        *ngIf="editForm.get('email')!.invalid && editForm.get('email')!.dirty || editForm.get('email')!.touched">
                         <small class="form-text text-danger"
-                               *ngIf="inviteForm.get('email')?.errors?.email"
+                               *ngIf="editForm.get('email')?.errors?.email"
                                jhiTranslate="entity.validation.email">
                         </small>
                         <small class="form-text text-danger"
-                               *ngIf="inviteForm.get('email')?.errors?.required"
+                               *ngIf="editForm.get('email')?.errors?.required"
                                jhiTranslate="entity.validation.required">
+                        </small>
+                        <small class="form-text text-danger"
+                               *ngIf="editForm.get('name')?.errors?.exists"
+                               jhiTranslate="entity.validation.uniqueness"
+                               [translateValues]="{ max: 50 }">
+                            This value has already been taken.
                         </small>
                     </div>
                 </div>
@@ -40,9 +46,9 @@
                                 [ngValue]="role"></option>
                     </select>
                     <div
-                        *ngIf="inviteForm.get('role')!.invalid && inviteForm.get('role')!.dirty || inviteForm.get('role')!.touched">
+                        *ngIf="editForm.get('role')!.invalid && editForm.get('role')!.dirty || editForm.get('role')!.touched">
                         <small class="form-text text-danger"
-                               *ngIf="inviteForm.get('role')?.errors?.required"
+                               *ngIf="editForm.get('role')?.errors?.required"
                                jhiTranslate="entity.validation.required">
                         </small>
                     </div>
@@ -62,7 +68,7 @@
                         valueExpr="name"
                         (onSelectionChanged)="responsibilitySelected($event)"
                         [showClearButton]="true"
-                        [isValid]="!(inviteForm.get('responsibility')!.invalid && inviteForm.get('responsibility')!.dirty || inviteForm.get('responsibility')!.touched)">
+                        [isValid]="!(editForm.get('responsibility')!.invalid && editForm.get('responsibility')!.dirty || editForm.get('responsibility')!.touched)">
                     </dx-autocomplete>
                 </div>
             </div>
@@ -75,7 +81,7 @@
                 </button>
 
                 <button type="submit" id="save-entity"
-                        [disabled]="inviteForm.pristine || inviteForm.invalid || isSaving"
+                        [disabled]="editForm.pristine || editForm.invalid || isSaving"
                         class="btn btn-primary">
                     <fa-icon icon="save"></fa-icon>&nbsp;
                     <span *ngIf="isNew" jhiTranslate="entity.action.inviteuser"></span>

--- a/src/test/java/io/github/bbortt/event/planner/service/InvitationServiceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/service/InvitationServiceIT.java
@@ -1,0 +1,31 @@
+package io.github.bbortt.event.planner.service;
+
+import io.github.bbortt.event.planner.AbstractApplicationContextAwareIT;
+import io.github.bbortt.event.planner.repository.InvitationRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.transaction.annotation.Transactional;
+
+@Sql({ "classpath:db/scripts/InvitationServiceIT_before.sql" })
+@Sql(value = { "classpath:db/scripts/InvitationServiceIT_after.sql" }, executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+public class InvitationServiceIT extends AbstractApplicationContextAwareIT {
+
+    @Autowired
+    InvitationRepository invitationRepository;
+
+    @Autowired
+    InvitationService invitationService;
+
+    @Test
+    @Transactional
+    public void invitationNotAcceptedElderThan14DaysDeleted() {
+        int sizeBeforeDeletion = invitationRepository.findAll().size();
+
+        invitationService.removeNotAcceptedInvitations();
+
+        Assertions.assertThat(invitationRepository.findAll().size()).isEqualTo(sizeBeforeDeletion - 1);
+    }
+}

--- a/src/test/java/io/github/bbortt/event/planner/service/InvitationServiceUnitTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/service/InvitationServiceUnitTest.java
@@ -1,0 +1,52 @@
+package io.github.bbortt.event.planner.service;
+
+import static org.mockito.Mockito.doReturn;
+
+import io.github.bbortt.event.planner.domain.Responsibility;
+import io.github.bbortt.event.planner.repository.InvitationRepository;
+import io.github.bbortt.event.planner.repository.UserRepository;
+import io.github.bbortt.event.planner.web.rest.InvitationResource;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class InvitationServiceUnitTest {
+
+    @Rule
+    MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    ProjectService projectServiceMock;
+
+    @Mock
+    InvitationRepository invitationRepositoryMock;
+
+    @Mock
+    UserRepository userRepositoryMock;
+
+    InvitationService fixture;
+
+    @Before
+    public void beforeTestSetup() {
+        fixture = new InvitationService(projectServiceMock, invitationRepositoryMock, userRepositoryMock);
+    }
+
+    @Test
+    void isNameExistingInProject() {
+        final Long locationId = 1234L;
+        final String email = "existing@email";
+
+        doReturn(Optional.of(new Responsibility())).when(invitationRepositoryMock).findOnyByEmailAndProjectId(email, locationId);
+
+        Assertions.assertThat(fixture.isEmailExistingInProject(locationId, email)).isTrue();
+
+        doReturn(Optional.empty()).when(invitationRepositoryMock).findOnyByEmailAndProjectId(email, locationId);
+
+        Assertions.assertThat(fixture.isEmailExistingInProject(locationId, email)).isFalse();
+    }
+}

--- a/src/test/java/io/github/bbortt/event/planner/service/LocationServiceUnitTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/service/LocationServiceUnitTest.java
@@ -73,7 +73,7 @@ class LocationServiceUnitTest {
     @Test
     void isNameExistingInProject() {
         final Long projectId = 1234L;
-        final String name = "text-existing-responsibility-name";
+        final String name = "test-existing-responsibility-name";
 
         doReturn(Optional.of(new Responsibility())).when(locationRepositoryMock).findOneByNameAndProjectId(name, projectId);
 

--- a/src/test/java/io/github/bbortt/event/planner/service/ResponsibilityServiceUnitTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/service/ResponsibilityServiceUnitTest.java
@@ -34,7 +34,7 @@ class ResponsibilityServiceUnitTest {
     @Test
     void isNameExistingInProject() {
         final Long projectId = 1234L;
-        final String name = "text-existing-responsibility-name";
+        final String name = "test-existing-responsibility-name";
 
         doReturn(Optional.of(new Responsibility())).when(responsibilityRepositoryMock).findOneByNameAndProjectId(name, projectId);
 

--- a/src/test/java/io/github/bbortt/event/planner/service/SectionServiceUnitTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/service/SectionServiceUnitTest.java
@@ -72,7 +72,7 @@ class SectionServiceUnitTest {
     @Test
     void isNameExistingInProject() {
         final Long locationId = 1234L;
-        final String name = "text-existing-responsibility-name";
+        final String name = "test-existing-responsibility-name";
 
         doReturn(Optional.of(new Responsibility())).when(sectionRepositoryMock).findOneByNameAndLocationId(name, locationId);
 

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/EventResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/EventResourceIT.java
@@ -48,8 +48,8 @@ import org.springframework.transaction.annotation.Transactional;
 @ExtendWith(MockitoExtension.class)
 class EventResourceIT extends AbstractApplicationContextAwareIT {
 
-    private static final String TEST_USER_LOGIN = "locationresourceit-login";
-    private static final String TEST_ADMIN_LOGIN = "responsibilityresourceit-admin";
+    private static final String TEST_USER_LOGIN = "eventresourceit-login";
+    private static final String TEST_ADMIN_LOGIN = "eventresourceit-admin";
 
     private static final String DEFAULT_NAME = "AAAAAAAAAA";
     private static final String UPDATED_NAME = "BBBBBBBBBB";

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/InvitationResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/InvitationResourceIT.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Integration tests for the {@link InvitationResource} REST controller.
  */
-class InvitationResourceIT extends AbstractApplicationContextAwareIT {
+public class InvitationResourceIT extends AbstractApplicationContextAwareIT {
 
     private static final String TEST_USER_LOGIN = "invitationresourceit-login";
     private static final String TEST_USER_EMAIL = "invitationresourceit@login";

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/LocationResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/LocationResourceIT.java
@@ -38,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 class LocationResourceIT extends AbstractApplicationContextAwareIT {
 
     private static final String TEST_USER_LOGIN = "locationresourceit-login";
-    private static final String TEST_ADMIN_LOGIN = "responsibilityresourceit-admin";
+    private static final String TEST_ADMIN_LOGIN = "locationresourceit-admin";
 
     private static final String DEFAULT_NAME = "AAAAAAAAAA";
     private static final String UPDATED_NAME = "BBBBBBBBBB";

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/ProjectResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/ProjectResourceIT.java
@@ -44,8 +44,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 class ProjectResourceIT extends AbstractApplicationContextAwareIT {
 
-    private static final String TEST_USER_LOGIN = "responsibilityresourceit-login";
-    private static final String TEST_ADMIN_LOGIN = "responsibilityresourceit-admin";
+    private static final String TEST_USER_LOGIN = "projectresourceit-login";
+    private static final String TEST_ADMIN_LOGIN = "projectresourceit-admin";
 
     private static final String DEFAULT_NAME = "AAAAAAAAAA";
     private static final String UPDATED_NAME = "BBBBBBBBBB";

--- a/src/test/java/io/github/bbortt/event/planner/web/rest/SectionResourceIT.java
+++ b/src/test/java/io/github/bbortt/event/planner/web/rest/SectionResourceIT.java
@@ -37,8 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 class SectionResourceIT extends AbstractApplicationContextAwareIT {
 
-    private static final String TEST_USER_LOGIN = "locationresourceit-login";
-    private static final String TEST_ADMIN_LOGIN = "responsibilityresourceit-admin";
+    private static final String TEST_USER_LOGIN = "sectionresourceit-login";
+    private static final String TEST_ADMIN_LOGIN = "sectionresourceit-admin";
 
     private static final String DEFAULT_NAME = "AAAAAAAAAA";
     private static final String UPDATED_NAME = "BBBBBBBBBB";

--- a/src/test/resources/db/scripts/InvitationServiceIT_after.sql
+++ b/src/test/resources/db/scripts/InvitationServiceIT_after.sql
@@ -1,0 +1,11 @@
+DELETE
+FROM invitation
+WHERE email IN ('InvitationServiceIT-user@localhost');
+
+DELETE
+FROM project
+WHERE name IN ('InvitationServiceIT-project-1', 'InvitationServiceIT-project-2');
+
+DELETE
+FROM jhi_user
+WHERE login IN ('InvitationServiceIT-user');

--- a/src/test/resources/db/scripts/InvitationServiceIT_before.sql
+++ b/src/test/resources/db/scripts/InvitationServiceIT_before.sql
@@ -1,0 +1,19 @@
+INSERT INTO jhi_user(login, email, password_hash, activated, created_by)
+VALUES ('InvitationServiceIT-user', 'InvitationServiceIT-user@localhost',
+        'some-password-hash-whatever', true, 'me');
+
+INSERT INTO project(name, start_time, end_time)
+VALUES ('InvitationServiceIT-project-1', now(), now()),
+       ('InvitationServiceIT-project-2', now(), now());
+
+INSERT INTO invitation(email, created_date, created_by, accepted, token, project_id, role_name,
+                       jhi_user_id)
+VALUES ('InvitationServiceIT-user@localhost',
+        to_timestamp('2020/01/01 00:00', 'YYYY/MM/DD HH24:MI'), 'me', false,
+        'ff4ebe9c-b817-4f76-835a-1f26899edd88',
+        (select id from project where name = 'InvitationServiceIT-project-1'), 'VIEWER',
+        (select id from jhi_user where login = 'InvitationServiceIT-user')),
+       ('InvitationServiceIT-user@localhost', now(), 'me', false,
+        'd5d5ce84-4b16-46fa-90b0-4a8a67b32d1c',
+        (select id from project where name = 'InvitationServiceIT-project-2'), 'VIEWER',
+        (select id from jhi_user where login = 'InvitationServiceIT-user'));

--- a/src/test/resources/db/scripts/ProjectRepositoryIT_before.sql
+++ b/src/test/resources/db/scripts/ProjectRepositoryIT_before.sql
@@ -7,7 +7,7 @@ VALUES ('ProjectRepositoryIT-project-1', now(), now()),
        ('ProjectRepositoryIT-project-2', now(), now()),
        ('ProjectRepositoryIT-project-3', now(), now());
 
-INSERT INTO INVITATION(email, accepted, project_id, role_name, jhi_user_id)
+INSERT INTO invitation(email, accepted, project_id, role_name, jhi_user_id)
 VALUES ('ProjectRepositoryIT-user-1@localhost', true, (select id from project where name = 'ProjectRepositoryIT-project-1'), 'VIEWER',
         (select id from jhi_user where login = 'ProjectRepositoryIT-user-1')),
        ('ProjectRepositoryIT-user-1@localhost', true, (select id from project where name = 'ProjectRepositoryIT-project-2'), 'VIEWER',

--- a/src/test/resources/db/scripts/RoleRepositoryIT_before.sql
+++ b/src/test/resources/db/scripts/RoleRepositoryIT_before.sql
@@ -8,13 +8,13 @@ INSERT INTO project(name, start_time, end_time)
 VALUES ('RoleRepositoryIT-project-1', now(), now()),
        ('RoleRepositoryIT-project-2', now(), now());
 
-INSERT INTO invitation(email, accepted, project_id, role_name, jhi_user_id)
+INSERT INTO invitation(email, accepted, project_id, role_name, jhi_user_id, created_by)
 VALUES ('RoleRepositoryIT-user-1@localhost', true,
         (select id from project where name = 'RoleRepositoryIT-project-1'), 'ADMIN',
-        (select id from jhi_user where login = 'RoleRepositoryIT-user-1')),
+        (select id from jhi_user where login = 'RoleRepositoryIT-user-1'), 'IT'),
        ('RoleRepositoryIT-user-2@localhost', false,
         (select id from project where name = 'RoleRepositoryIT-project-1'), 'ADMIN',
-        (select id from jhi_user where login = 'RoleRepositoryIT-user-2')),
+        (select id from jhi_user where login = 'RoleRepositoryIT-user-2'), 'IT'),
        ('RoleRepositoryIT-user-1@localhost', true,
         (select id from project where name = 'RoleRepositoryIT-project-2'), 'VIEWER',
-        (select id from jhi_user where login = 'RoleRepositoryIT-user-1'));
+        (select id from jhi_user where login = 'RoleRepositoryIT-user-1'), 'IT');


### PR DESCRIPTION
PR contains:
* invitation uniqueness `jhi_user_id` per `project_id`
* invitation frontend uniqueness check by `email`
* cleanup job which removes `Invitation` elder than 14 days
* email update which states the validity of the token
* invitation API security
* minor other test improvements, spelling mistakes fixed

closes #162.