### PR TITLE
assign default responsibility or user

### DIFF
--- a/src/main/java/io/github/bbortt/event/planner/domain/Invitation.java
+++ b/src/main/java/io/github/bbortt/event/planner/domain/Invitation.java
@@ -44,7 +44,7 @@ public class Invitation extends AbstractAuditingEntity implements Serializable {
     @Email
     @NotNull
     @Size(min = 5, max = 254)
-    @Column(name = "email", length = 254, nullable = false)
+    @Column(name = "email", length = 254, nullable = false, updatable = false)
     private String email;
 
     @NotNull
@@ -59,13 +59,14 @@ public class Invitation extends AbstractAuditingEntity implements Serializable {
     @Column(name = "color", length = 23)
     private String color;
 
-    @ManyToOne(optional = false)
     @NotNull
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_id", updatable = false)
     @JsonIgnoreProperties(value = "invitations", allowSetters = true)
     private Project project;
 
     @ManyToOne
-    @JoinColumn(name = "jhi_user_id")
+    @JoinColumn(name = "jhi_user_id", updatable = false)
     @JsonIgnoreProperties(value = "invitations", allowSetters = true)
     private User user;
 

--- a/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
+++ b/src/main/java/io/github/bbortt/event/planner/repository/InvitationRepository.java
@@ -28,5 +28,7 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
     Optional<Invitation> findOneByEmailAndProjectId(String email, Long projectId);
 
+    Optional<Invitation> findOneByUserIdAndProjectId(Long userId, Long projectId);
+
     List<Invitation> findAllByAcceptedIsFalseAndTokenIsNotNullAndCreatedDateBefore(Instant dateTime);
 }

--- a/src/main/java/io/github/bbortt/event/planner/service/InvitationService.java
+++ b/src/main/java/io/github/bbortt/event/planner/service/InvitationService.java
@@ -100,8 +100,14 @@ public class InvitationService {
 
     @Transactional(readOnly = true)
     public Optional<Invitation> findOneByEmailAndProjectId(String email, Long projectId) {
-        log.debug("Request to get Invitation for User {} in Project {}", email, projectId);
+        log.debug("Request to get Invitation by Email {} in Project {}", email, projectId);
         return invitationRepository.findOneByEmailAndProjectId(email, projectId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Invitation> findOneByUserIdAndProjectId(Long userId, Long projectId) {
+        log.debug("Request to get Invitation for User {} in Project {}", userId, projectId);
+        return invitationRepository.findOneByUserIdAndProjectId(userId, projectId);
     }
 
     /**

--- a/src/main/java/io/github/bbortt/event/planner/web/rest/SchedulerResource.java
+++ b/src/main/java/io/github/bbortt/event/planner/web/rest/SchedulerResource.java
@@ -128,7 +128,7 @@ public class SchedulerResource {
             colorGroupId = Responsibility.class.getSimpleName().toLowerCase() + "-" + event.getResponsibility().getId();
         } else if (event.getUser() != null) {
             color =
-                this.invitationService.findOneByEmailAndProjectId(event.getUser().getEmail(), section.getLocation().getProject().getId())
+                this.invitationService.findOneByUserIdAndProjectId(event.getUser().getId(), section.getLocation().getProject().getId())
                     .orElseThrow(IllegalArgumentException::new)
                     .getColor();
             colorGroupId = User.class.getSimpleName().toLowerCase() + "-" + event.getUser().getId();

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -17,7 +17,7 @@ email.signature=Event-Planer.
 
 # Creation email
 email.creation.text1=Dein Event-Planer Zugang wurde angelegt.
-email.creation.signin=Jetzt einloggen!
+email.creation.signin=Jetzt anmelden!
 
 # Reset email
 email.reset.title=Event-Planer Passwort zurücksetzen

--- a/src/main/webapp/app/shared/model/dto/scheduler-section.model.ts
+++ b/src/main/webapp/app/shared/model/dto/scheduler-section.model.ts
@@ -3,5 +3,6 @@ import { Section } from 'app/shared/model/section.model';
 export interface SchedulerSection {
   id: number;
   text: string;
+  description: string;
   originalSection: Section;
 }

--- a/src/main/webapp/app/shared/util/responsibility-or-user-from-form.ts
+++ b/src/main/webapp/app/shared/util/responsibility-or-user-from-form.ts
@@ -1,0 +1,21 @@
+import { FormGroup } from '@angular/forms';
+
+import { Responsibility } from 'app/shared/model/responsibility.model';
+import { User } from 'app/core/user/user.model';
+
+const responsibilityOrUserFromForm = (editForm: FormGroup, isResponsibility: boolean): { responsibility?: Responsibility; user?: User } => {
+  let responsibility;
+  let user;
+
+  if (isResponsibility) {
+    responsibility = editForm.get(['responsibilityAutocomplete'])!.value ? editForm.get(['responsibility'])!.value : null;
+    user = null;
+  } else {
+    responsibility = null;
+    user = editForm.get(['userAutocomplete'])!.value ? editForm.get(['user'])!.value : null;
+  }
+
+  return { responsibility, user };
+};
+
+export default responsibilityOrUserFromForm;

--- a/src/main/webapp/app/view/create-project/project-create.component.ts
+++ b/src/main/webapp/app/view/create-project/project-create.component.ts
@@ -38,8 +38,8 @@ export class ProjectCreateComponent implements OnInit, OnDestroy {
     description: [null, [Validators.maxLength(300)]],
     startTime: [null, [Validators.required]],
     endTime: [null, [Validators.required]],
-    selectedUser: [null, []],
-    selectedUserAutocomplete: [null, []],
+    selectedUser: [null, [Validators.required]],
+    selectedUserAutocomplete: [null],
   });
 
   dataSource: DataSource;

--- a/src/main/webapp/app/view/project/admin/locations/project-location-update.component.ts
+++ b/src/main/webapp/app/view/project/admin/locations/project-location-update.component.ts
@@ -18,6 +18,8 @@ import { User } from 'app/core/user/user.model';
 
 import { uniquePropertyValueInProjectValidator } from 'app/entities/validator/unique-property-value-in-project.validator';
 
+import responsibilityOrUserFromForm from 'app/shared/util/responsibility-or-user-from-form';
+
 @Component({
   selector: 'app-location-update',
   templateUrl: './project-location-update.component.html',
@@ -116,15 +118,7 @@ export class ProjectLocationUpdateComponent {
   }
 
   private createFromForm(): Location {
-    let responsibility;
-    let user;
-    if (this.isResponsibility) {
-      responsibility = this.editForm.get(['responsibility'])!.value;
-      user = null;
-    } else {
-      responsibility = null;
-      user = this.editForm.get(['user'])!.value;
-    }
+    const { responsibility, user } = responsibilityOrUserFromForm(this.editForm, this.isResponsibility);
 
     return {
       id: this.editForm.get(['id'])!.value,

--- a/src/main/webapp/app/view/project/admin/locations/sections/project-section-update.component.ts
+++ b/src/main/webapp/app/view/project/admin/locations/sections/project-section-update.component.ts
@@ -18,6 +18,8 @@ import { User } from 'app/core/user/user.model';
 
 import { uniquePropertyValueInLocationValidator } from 'app/entities/validator/unique-property-value-in-location.validator';
 
+import responsibilityOrUserFromForm from 'app/shared/util/responsibility-or-user-from-form';
+
 @Component({
   selector: 'app-section-update',
   templateUrl: './project-section-update.component.html',
@@ -115,15 +117,7 @@ export class ProjectSectionUpdateComponent implements OnInit {
   }
 
   private createFromForm(): Section {
-    let responsibility;
-    let user;
-    if (this.isResponsibility) {
-      responsibility = this.editForm.get(['responsibility'])!.value;
-      user = null;
-    } else {
-      responsibility = null;
-      user = this.editForm.get(['user'])!.value;
-    }
+    const { responsibility, user } = responsibilityOrUserFromForm(this.editForm, this.isResponsibility);
 
     return {
       id: this.editForm.get(['id'])!.value,

--- a/src/main/webapp/app/view/project/admin/users/project-user-invite.component.ts
+++ b/src/main/webapp/app/view/project/admin/users/project-user-invite.component.ts
@@ -93,7 +93,7 @@ export class ProjectUserInviteComponent {
       token: this.editForm.get('token')!.value,
       color: this.editForm.get('color')!.value,
       project: this.project!,
-      responsibility: this.editForm.get('responsibility')!.value,
+      responsibility: this.editForm.get('responsibilityAutocomplete')!.value ? this.editForm.get('responsibility')!.value : null,
       role: {
         name: (this.editForm.get('role')!.value as InternalRole).name,
       },

--- a/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.html
+++ b/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.html
@@ -1,0 +1,12 @@
+<div *ngIf="resource">
+    {{ resource.text }}
+    <br/>
+    <br/>
+    <div *ngIf="resource.originalSection.responsibility" class="resource-responsibility">
+            {{resource.originalSection.responsibility!.name}}
+    </div>
+
+    <div *ngIf="resource.originalSection.user" class="resource-responsibility">
+            {{resource.originalSection.user!.email}}
+    </div>
+</div>

--- a/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.scss
+++ b/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.scss
@@ -1,0 +1,4 @@
+.resource-responsibility {
+  font-weight: normal;
+  line-break: anywhere;
+}

--- a/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.ts
+++ b/src/main/webapp/app/view/project/screenplay/devextreme/scheduler-resource.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+import { SchedulerSection } from 'app/shared/model/dto/scheduler-section.model';
+
+@Component({
+  selector: 'app-scheduler-resource',
+  templateUrl: './scheduler-resource.component.html',
+  styleUrls: ['./scheduler-resource.component.scss'],
+})
+export class SchedulerResourceComponent {
+  @Input()
+  resource?: SchedulerSection;
+}

--- a/src/main/webapp/app/view/project/screenplay/event/event-update.component.ts
+++ b/src/main/webapp/app/view/project/screenplay/event/event-update.component.ts
@@ -102,7 +102,18 @@ export class EventUpdateComponent implements OnInit, OnDestroy {
 
     this.minEndDate = newStartTime;
 
+    const { id, name, description, sections } = event;
+    let { responsibility, user } = event;
+
     if (!isReadonly) {
+      if (this.section.responsibility || this.section.user) {
+        responsibility = this.section.responsibility;
+        user = this.section.user;
+      } else if (this.location!.responsibility || this.location!.user) {
+        responsibility = this.location!.responsibility;
+        user = this.location!.user;
+      }
+
       this.responsibilityService
         .findAllByProject(this.project, { sort: ['name,asc'] })
         .subscribe((response: HttpResponse<Responsibility[]>) => (this.responsibilities = response.body || []));
@@ -112,18 +123,18 @@ export class EventUpdateComponent implements OnInit, OnDestroy {
         .subscribe((response: HttpResponse<User[]>) => (this.users = response.body || []));
     }
 
-    this.isResponsibility = !event.user;
+    this.isResponsibility = !user;
     this.editForm.patchValue({
-      id: event.id,
-      name: event.name,
-      description: event.description,
+      id,
+      name,
+      description,
       startTime: newStartTime,
       endTime: newEndTime,
-      sections: event.sections,
-      responsibility: event.responsibility,
-      responsibilityAutocomplete: event.responsibility?.name,
-      user: event.user,
-      userAutocomplete: event.user?.email,
+      sections,
+      responsibility,
+      responsibilityAutocomplete: responsibility?.name,
+      user,
+      userAutocomplete: user?.email,
     });
   }
 

--- a/src/main/webapp/app/view/project/screenplay/event/event-update.component.ts
+++ b/src/main/webapp/app/view/project/screenplay/event/event-update.component.ts
@@ -25,6 +25,8 @@ import { DATE_TIME_FORMAT } from 'app/shared/constants/input.constants';
 import { AUTHORITY_ADMIN } from 'app/shared/constants/authority.constants';
 import { VIEWER } from 'app/shared/constants/role.constants';
 
+import responsibilityOrUserFromForm from 'app/shared/util/responsibility-or-user-from-form';
+
 import * as moment from 'moment';
 
 @Component({
@@ -188,15 +190,7 @@ export class EventUpdateComponent implements OnInit, OnDestroy {
   }
 
   private createFromForm(): Event {
-    let responsibility;
-    let user;
-    if (this.isResponsibility) {
-      responsibility = this.editForm.get(['responsibility'])!.value;
-      user = null;
-    } else {
-      responsibility = null;
-      user = this.editForm.get(['user'])!.value;
-    }
+    const { responsibility, user } = responsibilityOrUserFromForm(this.editForm, this.isResponsibility);
 
     return {
       id: this.editForm.get(['id'])!.value,

--- a/src/main/webapp/app/view/project/screenplay/project-screenplay-location.component.html
+++ b/src/main/webapp/app/view/project/screenplay/project-screenplay-location.component.html
@@ -10,7 +10,7 @@
         <dx-scheduler
             [dataSource]="events"
             appointmentTemplate="eventTemplate"
-            appointmentTooltipTemplate="tooltipTemplate"
+            resourceCellTemplate="resourceTemplate"
             [currentDate]="schedulerStartDate"
             [min]="project!.startTime.toDate()"
             [max]="project!.endTime.toDate()"
@@ -44,6 +44,11 @@
             <div *dxTemplate="let model of 'eventTemplate'">
                 <app-scheduler-appointment
                     [appointment]="model.appointmentData"></app-scheduler-appointment>
+            </div>
+
+            <div *dxTemplate="let model of 'resourceTemplate'">
+                <app-scheduler-resource
+                    [resource]="model.data"></app-scheduler-resource>
             </div>
         </dx-scheduler>
     </div>

--- a/src/main/webapp/app/view/project/screenplay/project-screenplay.module.ts
+++ b/src/main/webapp/app/view/project/screenplay/project-screenplay.module.ts
@@ -12,6 +12,7 @@ import { ProjectScreenplayFilterComponent } from 'app/view/project/screenplay/fi
 import { ProjectScreenplayLocationComponent } from 'app/view/project/screenplay/project-screenplay-location.component';
 
 import { SchedulerAppointmentComponent } from 'app/view/project/screenplay/devextreme/scheduler-appointment.component';
+import { SchedulerResourceComponent } from 'app/view/project/screenplay/devextreme/scheduler-resource.component';
 
 import { PROJECT_SCREENPLAY_ROUTES } from './project-screenplay.routes';
 
@@ -30,6 +31,7 @@ import { PROJECT_SCREENPLAY_ROUTES } from './project-screenplay.routes';
     ProjectScreenplayFilterComponent,
     ProjectScreenplayLocationComponent,
     SchedulerAppointmentComponent,
+    SchedulerResourceComponent,
   ],
   entryComponents: [ProjectScreenplayComponent],
 })

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -42,6 +42,9 @@
         "register": {
           "noaccount": "Sie haben noch keinen Zugang?",
           "link": "Registrieren Sie sich"
+        },
+        "authenticated": {
+          "link": "anmelden"
         }
       },
       "error": {

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -106,6 +106,7 @@
       "pattern": "Dieses Feld muss das Muster {{pattern}} erfüllen.",
       "number": "Dieses Feld muss eine Zahl sein.",
       "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten.",
+      "patternLogin": "Dieses Feld kann nur Buchstaben, Zahlen und Email Adressen enthalten.",
       "email": "Bitte gib eine gültige Email-Adresse ein.",
       "uniqueness": "Dieser Wert ist bereits vergeben."
     }

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -42,6 +42,9 @@
         "register": {
           "noaccount": "You don't have an account yet?",
           "link": "Register a new account"
+        },
+        "authenticated": {
+          "link": "Sign In"
         }
       },
       "error": {


### PR DESCRIPTION
if a `Location` or `Section` has a `Responsibility` or `User`: inherit it into the new `Event`.
customized the scheduler section (sidebar) as well. it does now display the section name as well as its responsibility. but I might rework it again, because the `Location` responsibility is not visible yet. maybe display this one and then the `Section` responsibility only if it differs from the "super" responsibility.

closes #178.