### PR TITLE
ci: fix docker publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/metadata-action@v3
+      - id: meta
+        uses: docker/metadata-action@v3
         with:
           images: bbortt/event-planner
           tags: |


### PR DESCRIPTION
the metadata stage actually requires the id because the next steps
cannot use the output otherwise.