### PR TITLE
fix(wiremock): wiremock evaluates templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,11 @@ test {
     exclude "**/*IntegrationTest*"
 }
 
-//task integrationTest(type: Test, dependsOn: test) {
-//    useJUnitPlatform()
-//    include "**/*IntegrationTest*"
-//}
-//bootJar.dependsOn integrationTest
+task integrationTest(type: Test, dependsOn: test) {
+    useJUnitPlatform()
+    include "**/*IntegrationTest*"
+}
+bootJar.dependsOn integrationTest
 
 // --- Frontend Build ---
 task lint(type: NpmTask, dependsOn: "npmInstall") {

--- a/src/test/java/io/github/bbortt/event/planner/AbstractApplicationContextAwareIntegrationTest.java
+++ b/src/test/java/io/github/bbortt/event/planner/AbstractApplicationContextAwareIntegrationTest.java
@@ -1,6 +1,6 @@
 package io.github.bbortt.event.planner;
 
-import io.github.bbortt.event.planner.config.WireMockTemplateTransformerConfig;
+import io.github.bbortt.event.planner.config.WireMockCustomizerConfig;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
@@ -8,6 +8,6 @@ import org.springframework.context.annotation.Import;
 
 @AutoConfigureMockMvc
 @AutoConfigureWireMock(port = 0)
-@Import({ WireMockTemplateTransformerConfig.class })
+@Import({ WireMockCustomizerConfig.class })
 @SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class AbstractApplicationContextAwareIntegrationTest {}

--- a/src/test/java/io/github/bbortt/event/planner/config/WireMockCustomizerConfig.java
+++ b/src/test/java/io/github/bbortt/event/planner/config/WireMockCustomizerConfig.java
@@ -1,14 +1,15 @@
 package io.github.bbortt.event.planner.config;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import org.springframework.cloud.contract.wiremock.WireMockConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class WireMockTemplateTransformerConfig {
+public class WireMockCustomizerConfig {
 
   @Bean
-  public ResponseTemplateTransformer responseTemplateTransformer() {
-    return new ResponseTemplateTransformer(true);
+  WireMockConfigurationCustomizer optionsCustomizer() {
+    return options -> options.extensions(new ResponseTemplateTransformer(true));
   }
 }


### PR DESCRIPTION
with the spring customization, wiremock finally evaluates teamplate
variables again. re-enable integration tests in build pipeline.